### PR TITLE
Dev/beacon-dispatcher

### DIFF
--- a/Client/Source/KiwiApp_BeaconDispatcher.cpp
+++ b/Client/Source/KiwiApp_BeaconDispatcher.cpp
@@ -47,6 +47,7 @@ namespace kiwi
         m_message_editor.setReturnKeyStartsNewLine(false);
         m_message_editor.setMultiLine(false, false);
         
+        // message slider
         m_message_slider.setRange(0., 1.);
         m_message_slider.setSliderStyle(juce::Slider::SliderStyle::LinearHorizontal);
         m_message_slider.addListener(this);

--- a/Client/Source/KiwiApp_BeaconDispatcher.cpp
+++ b/Client/Source/KiwiApp_BeaconDispatcher.cpp
@@ -28,66 +28,63 @@ namespace kiwi
     //                                  BEACON DISPATCHER                               //
     // ================================================================================ //
     
-    BeaconDispatcher::BeaconDispatcher(engine::Instance& instance) : m_instance(instance)
+    BeaconDispatcher::BeaconDispatcher(engine::Instance& instance) :
+    m_instance(instance),
+    m_beacon_name_editor("beacon_name_editor"),
+    m_message_editor("message_editor"),
+    m_beacon_name_label("beacon_name_label", "Name: "),
+    m_message_label("message_label", "Message: "),
+    m_send_button("Send")
     {
         setInterceptsMouseClicks(false, true);
         
         // beacon name field
-        m_beacon_name_editor.reset(new juce::TextEditor("beacon_name_editor"));
-        m_beacon_name_editor->setReturnKeyStartsNewLine(false);
-        m_beacon_name_editor->setMultiLine(false, false);
-        m_beacon_name_editor->setColour(juce::TextEditor::highlightColourId,
-                                        juce::Colour::fromFloatRGBA(0., 0.5, 1., 0.4));
-        
-        m_beacon_name_editor->setColour(juce::TextEditor::focusedOutlineColourId,
-                                        juce::Colour::fromFloatRGBA(0.4, 0.4, 0.4, 0.6));
-        
-        m_beacon_name_editor->setColour(juce::TextEditor::outlineColourId,
-                                        juce::Colour::fromFloatRGBA(0.6, 0.6, 0.6, 0.6));
-        
-        m_beacon_name_editor->setColour(juce::TextEditor::backgroundColourId, juce::Colours::transparentWhite);
+        m_beacon_name_editor.setReturnKeyStartsNewLine(false);
+        m_beacon_name_editor.setMultiLine(false, false);
         
         // message field
-        m_message_editor.reset(new juce::TextEditor("message_editor"));
-        m_message_editor->setReturnKeyStartsNewLine(false);
-        m_message_editor->setMultiLine(false, false);
-        m_message_editor->setColour(juce::TextEditor::highlightColourId,
-                                        juce::Colour::fromFloatRGBA(0., 0.5, 1., 0.4));
-        
-        m_message_editor->setColour(juce::TextEditor::focusedOutlineColourId,
-                                    juce::Colour::fromFloatRGBA(0.4, 0.4, 0.4, 0.6));
-        
-        m_message_editor->setColour(juce::TextEditor::outlineColourId,
-                                    juce::Colour::fromFloatRGBA(0.6, 0.6, 0.6, 0.6));
-        
-        m_message_editor->setColour(juce::TextEditor::backgroundColourId, juce::Colours::transparentWhite);
+        m_message_editor.setReturnKeyStartsNewLine(false);
+        m_message_editor.setMultiLine(false, false);
         
         //button
-        m_send_button.reset(new juce::TextButton("Send"));
-        m_send_button->addListener(this);
+        m_send_button.addListener(this);
         
-        addAndMakeVisible(m_beacon_name_editor.get());
-        addAndMakeVisible(m_message_editor.get());
-        addAndMakeVisible(m_send_button.get());
+        addAndMakeVisible(m_beacon_name_label);
+        addAndMakeVisible(m_beacon_name_editor);
+        addAndMakeVisible(m_message_editor);
+        addAndMakeVisible(m_message_label);
+        addAndMakeVisible(m_send_button);
         
-        setSize(280, 75);
+        setSize(280, 120);
     }
     
     void BeaconDispatcher::resized()
     {
-        m_beacon_name_editor->setBounds(10, 10, getWidth() - 20, 20);
-        m_message_editor->setBounds(10, 40, getWidth() - 20, 20);
+        auto bounds = getLocalBounds();
         
-        m_send_button->setSize(60, 20);
-        m_send_button->setTopRightPosition(getWidth() - 10, 70);
+        int padding = 4;
+        int row_height = 40;
+        int label_height = 20;
+        
+        auto row_bounds = bounds.removeFromTop(row_height);
+        m_beacon_name_label.setBounds(row_bounds.removeFromTop(label_height));
+        m_beacon_name_editor.setBounds(row_bounds.reduced(padding, 0));
+        
+        row_bounds = bounds.removeFromTop(row_height);
+        m_message_label.setBounds(row_bounds.removeFromTop(label_height));
+        m_message_editor.setBounds(row_bounds.reduced(padding, 0));
+        
+        row_bounds = bounds.removeFromTop(30);
+        m_send_button.setSize(60, 20);
+        m_send_button.setTopRightPosition(getWidth() - padding, row_bounds.getY() + 10);
     }
     
     void BeaconDispatcher::buttonClicked(juce::Button* btn)
     {
-        if(btn == m_send_button.get())
+        if(btn == &m_send_button)
         {
-            std::string name = m_beacon_name_editor->getText().toStdString();
-            std::string args = m_message_editor->getText().toStdString();
+            std::string name = m_beacon_name_editor.getText().toStdString();
+            std::string args = m_message_editor.getText().toStdString();
             send(name, AtomHelper::parse(args));
         }
     }

--- a/Client/Source/KiwiApp_BeaconDispatcher.cpp
+++ b/Client/Source/KiwiApp_BeaconDispatcher.cpp
@@ -34,6 +34,7 @@ namespace kiwi
     m_message_editor("message_editor"),
     m_beacon_name_label("beacon_name_label", "Name: "),
     m_message_label("message_label", "Message: "),
+    m_message_slider("message_slider"),
     m_send_button("Send")
     {
         setInterceptsMouseClicks(false, true);
@@ -46,6 +47,10 @@ namespace kiwi
         m_message_editor.setReturnKeyStartsNewLine(false);
         m_message_editor.setMultiLine(false, false);
         
+        m_message_slider.setRange(0., 1.);
+        m_message_slider.setSliderStyle(juce::Slider::SliderStyle::LinearHorizontal);
+        m_message_slider.addListener(this);
+        
         //button
         m_send_button.addListener(this);
         
@@ -53,30 +58,39 @@ namespace kiwi
         addAndMakeVisible(m_beacon_name_editor);
         addAndMakeVisible(m_message_editor);
         addAndMakeVisible(m_message_label);
+        addAndMakeVisible(m_message_slider);
         addAndMakeVisible(m_send_button);
         
-        setSize(280, 120);
+        setSize(310, 150);
+    }
+    
+    BeaconDispatcher::~BeaconDispatcher()
+    {
+        m_message_slider.removeListener(this);
+        m_send_button.removeListener(this);
     }
     
     void BeaconDispatcher::resized()
     {
-        auto bounds = getLocalBounds();
-        
         int padding = 4;
-        int row_height = 40;
+        int row_height = 44;
         int label_height = 20;
+        
+        auto bounds = getLocalBounds().reduced(padding);
         
         auto row_bounds = bounds.removeFromTop(row_height);
         m_beacon_name_label.setBounds(row_bounds.removeFromTop(label_height));
-        m_beacon_name_editor.setBounds(row_bounds.reduced(padding, 0));
+        row_bounds.reduce(padding, 0);
+        m_beacon_name_editor.setBounds(row_bounds);
         
         row_bounds = bounds.removeFromTop(row_height);
         m_message_label.setBounds(row_bounds.removeFromTop(label_height));
-        m_message_editor.setBounds(row_bounds.reduced(padding, 0));
+        m_send_button.setBounds(row_bounds.removeFromRight(60).reduced(padding, 0));
+        row_bounds.reduce(padding, 0);
+        m_message_editor.setBounds(row_bounds);
         
-        row_bounds = bounds.removeFromTop(30);
-        m_send_button.setSize(60, 20);
-        m_send_button.setTopRightPosition(getWidth() - padding, row_bounds.getY() + 10);
+        row_bounds = bounds.removeFromTop(row_height);
+        m_message_slider.setBounds(row_bounds.removeFromBottom(30).withLeft(padding * 2));
     }
     
     void BeaconDispatcher::buttonClicked(juce::Button* btn)
@@ -86,6 +100,15 @@ namespace kiwi
             std::string name = m_beacon_name_editor.getText().toStdString();
             std::string args = m_message_editor.getText().toStdString();
             send(name, AtomHelper::parse(args));
+        }
+    }
+    
+    void BeaconDispatcher::sliderValueChanged(juce::Slider* slider)
+    {
+        if(slider == &m_message_slider)
+        {
+            std::string name = m_beacon_name_editor.getText().toStdString();
+            send(name, {m_message_slider.getValue()});
         }
     }
     

--- a/Client/Source/KiwiApp_BeaconDispatcher.hpp
+++ b/Client/Source/KiwiApp_BeaconDispatcher.hpp
@@ -33,9 +33,7 @@ namespace kiwi
     // ================================================================================ //
     
     //! @brief A Component that allows to dispatch messages to Beacon::Castaway objects.
-    class BeaconDispatcher :
-    public juce::Component,
-    public juce::Button::Listener
+    class BeaconDispatcher : public juce::Component, public juce::Button::Listener
     {
     public:
         
@@ -58,10 +56,10 @@ namespace kiwi
         
     private: // members
         
-        engine::Instance&                   m_instance;
-        std::unique_ptr<juce::TextEditor>   m_beacon_name_editor;
-        std::unique_ptr<juce::TextEditor>   m_message_editor;
-        std::unique_ptr<juce::TextButton>   m_send_button;
+        engine::Instance&   m_instance;
+        juce::TextEditor    m_beacon_name_editor, m_message_editor;
+        juce::Label         m_beacon_name_label, m_message_label;
+        juce::TextButton    m_send_button;
     };
 }
 

--- a/Client/Source/KiwiApp_BeaconDispatcher.hpp
+++ b/Client/Source/KiwiApp_BeaconDispatcher.hpp
@@ -33,7 +33,7 @@ namespace kiwi
     // ================================================================================ //
     
     //! @brief A Component that allows to dispatch messages to Beacon::Castaway objects.
-    class BeaconDispatcher : public juce::Component, public juce::Button::Listener
+    class BeaconDispatcher : public juce::Component, public juce::Button::Listener, juce::Slider::Listener
     {
     public:
         
@@ -41,7 +41,7 @@ namespace kiwi
         BeaconDispatcher(engine::Instance& instance);
         
         //! @brief Destructor.
-        ~BeaconDispatcher() = default;
+        ~BeaconDispatcher();
         
         //! @brief Called when resized.
         void resized() override;
@@ -54,11 +54,17 @@ namespace kiwi
         //! @brief dispatch message to castaways
         void send(std::string const& name, std::vector<Atom> const& args) const;
         
+        //! @brief Called when a slider value changed.
+        void sliderValueChanged(juce::Slider* slider) override;
+        
     private: // members
         
         engine::Instance&   m_instance;
         juce::TextEditor    m_beacon_name_editor, m_message_editor;
         juce::Label         m_beacon_name_label, m_message_label;
+        
+        juce::Slider        m_message_slider;
+        
         juce::TextButton    m_send_button;
     };
 }

--- a/Client/Source/KiwiApp_Components/KiwiApp_SuggestEditor.cpp
+++ b/Client/Source/KiwiApp_Components/KiwiApp_SuggestEditor.cpp
@@ -288,6 +288,7 @@ namespace kiwi
     
     void SuggestEditor::returnPressed()
     {
+        TextEditor::returnPressed();
         m_listeners.call(&Listener::suggestEditorReturnKeyPressed, *this);
     }
     

--- a/Client/Source/KiwiApp_LookAndFeel.cpp
+++ b/Client/Source/KiwiApp_LookAndFeel.cpp
@@ -35,6 +35,8 @@ namespace kiwi
         setColour(juce::TextEditor::highlightColourId, juce::Colour::fromFloatRGBA(0., 0.5, 1., 0.4));
         setColour(juce::TextEditor::focusedOutlineColourId, juce::Colour::fromFloatRGBA(0.4, 0.4, 0.4, 0.6));
         setColour(juce::TextEditor::outlineColourId, juce::Colour::fromFloatRGBA(0.6, 0.6, 0.6, 0.6));
+        
+        setColour(juce::TextButton::buttonColourId, juce::Colour(0xffdedede));
     }
     
     juce::Typeface::Ptr LookAndFeel::getTypefaceForFont(juce::Font const& font)
@@ -161,6 +163,44 @@ namespace kiwi
         for(int i = header.getNumColumns(true) - 1; --i >= 0;)
         {
             g.fillRect(header.getColumnPosition(i).removeFromRight(1));
+        }
+    }
+    
+    void LookAndFeel::drawButtonBackground(juce::Graphics& g, juce::Button& btn,
+                                           juce::Colour const& bgcolor,
+                                           bool mouse_over, bool mouse_down)
+    {
+        juce::Colour baseColour(bgcolor.withMultipliedSaturation(btn.hasKeyboardFocus (true) ? 1.3f : 0.9f).withMultipliedAlpha(btn.isEnabled() ? 0.9f : 0.5f));
+        
+        if (mouse_down || mouse_over)
+            baseColour = baseColour.contrasting(mouse_down ? 0.2f : 0.1f);
+        
+        const bool flatOnLeft   = btn.isConnectedOnLeft();
+        const bool flatOnRight  = btn.isConnectedOnRight();
+        const bool flatOnTop    = btn.isConnectedOnTop();
+        const bool flatOnBottom = btn.isConnectedOnBottom();
+        
+        const float width  = btn.getWidth() - 1.0f;
+        const float height = btn.getHeight() - 1.0f;
+        
+        if(width > 0 && height > 0)
+        {
+            const float cornerSize = 1.0f;
+            
+            juce::Path outline;
+            outline.addRoundedRectangle(0.5f, 0.5f, width, height, cornerSize, cornerSize,
+                                        ! (flatOnLeft  || flatOnTop),
+                                        ! (flatOnRight || flatOnTop),
+                                        ! (flatOnLeft  || flatOnBottom),
+                                        ! (flatOnRight || flatOnBottom));
+            
+            
+            
+            g.setColour(baseColour);
+            g.fillPath(outline);
+            
+            g.setColour(btn.hasKeyboardFocus(false) ? baseColour.contrasting(0.5) : baseColour.contrasting(0.2));
+            g.strokePath(outline, juce::PathStrokeType(1.0f));
         }
     }
 }

--- a/Client/Source/KiwiApp_LookAndFeel.cpp
+++ b/Client/Source/KiwiApp_LookAndFeel.cpp
@@ -30,6 +30,11 @@ namespace kiwi
     {
         setColour(juce::TooltipWindow::backgroundColourId, juce::Colours::lightgrey);
         setColour(juce::TooltipWindow::textColourId, juce::Colour(0xff444444));
+        
+        // text editors
+        setColour(juce::TextEditor::highlightColourId, juce::Colour::fromFloatRGBA(0., 0.5, 1., 0.4));
+        setColour(juce::TextEditor::focusedOutlineColourId, juce::Colour::fromFloatRGBA(0.4, 0.4, 0.4, 0.6));
+        setColour(juce::TextEditor::outlineColourId, juce::Colour::fromFloatRGBA(0.6, 0.6, 0.6, 0.6));
     }
     
     juce::Typeface::Ptr LookAndFeel::getTypefaceForFont(juce::Font const& font)

--- a/Client/Source/KiwiApp_LookAndFeel.hpp
+++ b/Client/Source/KiwiApp_LookAndFeel.hpp
@@ -55,6 +55,11 @@ namespace kiwi
                                    bool isMouseOver, bool isMouseDown,
                                    int columnFlags) override;
         
+        //! @brief Custom Button background drawing
+        void drawButtonBackground(juce::Graphics& g, juce::Button& b,
+                                  juce::Colour const& bgcolor,
+                                  bool mouse_over, bool mouse_down) override;
+        
     private: // deleted methods
         
         LookAndFeel(LookAndFeel const& other) = delete;

--- a/Client/Source/KiwiApp_Window.cpp
+++ b/Client/Source/KiwiApp_Window.cpp
@@ -81,7 +81,13 @@ namespace kiwi
             
             if(window_state.isNotEmpty())
             {
+                auto last_bounds = getBounds();
                 restoreWindowStateFromString(window_state);
+                
+                if(!isResizable())
+                {
+                    setSize(last_bounds.getWidth(), last_bounds.getHeight());
+                }
             }
         }
     }


### PR DESCRIPTION
- Add labels to the beacon dispatcher Component.
- Add a slider to the beacon dispatcher Component.
- Ignore window size user settings for windows that aren’t resizables.
- Override drawButtonBackground() LookAndFeel method.