### PR TITLE
dev/connect-status

### DIFF
--- a/Client/Source/KiwiApp.cpp
+++ b/Client/Source/KiwiApp.cpp
@@ -81,12 +81,14 @@ namespace kiwi
     
     void KiwiApp::initialise(juce::String const& commandLine)
     {
+        #if ! JUCE_MAC
         if(sendCommandLineToPreexistingInstance())
         {
             DBG ("Another instance is running - quitting...");
             quit();
             return;
         }
+        #endif
    
         model::DataModel::init();
         

--- a/Client/Source/KiwiApp.cpp
+++ b/Client/Source/KiwiApp.cpp
@@ -414,7 +414,13 @@ namespace kiwi
     {
         menu.addCommandItem(m_command_manager.get(), CommandIDs::startDsp);
         menu.addCommandItem(m_command_manager.get(), CommandIDs::stopDsp);
+        
+        menu.addSeparator();
         menu.addCommandItem(m_command_manager.get(), CommandIDs::showAudioStatusWindow);
+        
+        #if ! JUCE_MAC
+        menu.addCommandItem(&getCommandManager(), CommandIDs::showAppSettingsWindow);
+        #endif
     }
     
     void KiwiApp::createWindowMenu(juce::PopupMenu& menu)

--- a/Client/Source/KiwiApp_Network/KiwiApp_DocumentManager.cpp
+++ b/Client/Source/KiwiApp_Network/KiwiApp_DocumentManager.cpp
@@ -19,10 +19,10 @@
  ==============================================================================
  */
 
-#include <flip/BackEndIR.h>
-#include <flip/BackEndBinary.h>
-#include <flip/contrib/DataConsumerFile.h>
-#include <flip/contrib/DataProviderFile.h>
+#include "flip/BackEndIR.h"
+#include "flip/BackEndBinary.h"
+#include "flip/contrib/DataConsumerFile.h"
+#include "flip/contrib/DataProviderFile.h"
 
 #include <KiwiModel/KiwiModel_PatcherUser.h>
 

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherComponent.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherComponent.cpp
@@ -77,13 +77,13 @@ namespace kiwi
         ids.add(spacerId);
         ids.add(flexibleSpacerId);
         ids.add(ItemIds::dsp_on_off);
-        //ids.add(ItemIds::users);
+        ids.add(ItemIds::users);
     }
     
     void PatcherToolbar::Factory::getDefaultItemSet(juce::Array<int>& ids)
     {
-        //ids.add(ItemIds::users);
-        //ids.add(separatorBarId);
+        ids.add(ItemIds::users);
+        ids.add(separatorBarId);
         ids.add(ItemIds::dsp_on_off);
         ids.add(separatorBarId);
         ids.add(ItemIds::lock_unlock);
@@ -125,12 +125,10 @@ namespace kiwi
                                           IMG(dsp_off_png), IMG(dsp_on_png));
             btn->setCommandToTrigger(&KiwiApp::getCommandManager(), CommandIDs::switchDsp, true);
         }
-        /*
         else if(itemId == ItemIds::users)
         {
             btn = new UsersItemComponent(itemId, m_patcher_manager);
         }
-        */
         
         return btn;
     }
@@ -193,9 +191,7 @@ namespace kiwi
         if (isVertical)
             return false;
         
-        preferredSize = toolbarDepth * 2;
-        minSize = preferredSize;
-        maxSize = 300;
+        maxSize = minSize = preferredSize = 50;
         return true;
     }
     

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherComponent.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherComponent.cpp
@@ -77,13 +77,21 @@ namespace kiwi
         ids.add(spacerId);
         ids.add(flexibleSpacerId);
         ids.add(ItemIds::dsp_on_off);
-        ids.add(ItemIds::users);
+        
+        if(m_patcher_manager.isRemote())
+        {
+            ids.add(ItemIds::users);
+        }
     }
     
     void PatcherToolbar::Factory::getDefaultItemSet(juce::Array<int>& ids)
     {
-        ids.add(ItemIds::users);
-        ids.add(separatorBarId);
+        if(m_patcher_manager.isRemote())
+        {
+            ids.add(ItemIds::users);
+            ids.add(separatorBarId);
+        }
+        
         ids.add(ItemIds::dsp_on_off);
         ids.add(separatorBarId);
         ids.add(ItemIds::lock_unlock);

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherComponent.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherComponent.h
@@ -83,42 +83,57 @@ namespace kiwi
     // ================================================================================ //
     
     //! @brief A toolbar component that displays informations about the users of the patch
-    class PatcherToolbar::UsersItemComponent :
-    public juce::ToolbarItemComponent,
-    public PatcherManager::Listener
+    class PatcherToolbar::UsersItemComponent
+    : public juce::ToolbarItemComponent
+    , public PatcherManager::Listener
+    , private juce::Timer
     {
     public: // methods
         
+        //! @brief Constructor.
         UsersItemComponent(const int toolbarItemId, PatcherManager& patcher_manager);
         
+        //! @brief Destructor.
         ~UsersItemComponent();
         
         //! @brief Called when one or more users are connecting or disconnecting to the Patcher Document.
         void connectedUserChanged(PatcherManager& manager) override;
         
+        //! @brief Provides prefered size for this item.
         bool getToolbarItemSizes(int toolbarDepth, bool isVertical,
                                  int& preferredSize, int& minSize, int& maxSize) override;
         
+        //! @brief Paint the button area.
         void paintButtonArea(juce::Graphics&, int width, int height,
                              bool isMouseOver, bool isMouseDown) override;
         
+        //! @brief Called when content area changed.
         void contentAreaChanged(const juce::Rectangle<int>& newArea) override;
         
-        void mouseEnter(juce::MouseEvent const& e) override;
-        void mouseExit(juce::MouseEvent const& e) override;
+        //! @brief Starts this component flashing.
+        void startFlashing();
+        
+        //! @brief Stops this component flashing.
+        void stopFlashing();
+        
+    private: // methods
+        
+        //! @internal juce::Timer callback.
+        void timerCallback() override;
         
     private: // variables
         
         PatcherManager&     m_patcher_manager;
         size_t              m_users;
         const juce::Image   m_users_img;
+        float               m_flash_alpha = 0.f;
     };
     
     // ================================================================================ //
     //                                PATCHER COMPONENT                                 //
     // ================================================================================ //
     
-    //! @brief The PatcherView Viewport
+    //! @brief The PatcherComponent holds a patcher view and a patcher toolbar.
     class PatcherComponent :
     public juce::Component,
     public juce::ApplicationCommandTarget

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherComponent.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherComponent.h
@@ -56,7 +56,7 @@ namespace kiwi
                 zoom_in             = 2,
                 zoom_out            = 3,
                 dsp_on_off          = 4,
-                //users               = 5,
+                users               = 5,
             };
             
             void getAllToolbarItemIds(juce::Array<int>& ids) override;

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherManager.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherManager.cpp
@@ -172,6 +172,11 @@ namespace kiwi
         return m_connected_users.size();
     }
     
+    std::unordered_set<uint64_t> PatcherManager::getConnectedUsers()
+    {
+        return m_connected_users;
+    }
+    
     size_t PatcherManager::getNumberOfView()
     {
         auto& patcher = getPatcher();

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherManager.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherManager.cpp
@@ -82,6 +82,32 @@ namespace kiwi
         
         model::Patcher& patcher = getPatcher();
         
+        m_user_connected_signal_cnx = patcher.signal_user_connect.connect([this](uint64_t user_id){
+            
+            if(m_connected_users.insert(user_id).second)
+            {
+                m_listeners.call(&Listener::connectedUserChanged, *this);
+            }
+        });
+        
+        m_user_disconnected_signal_cnx = patcher.signal_user_disconnect.connect([this](uint64_t user_id){
+            
+            const auto user_to_erase = m_connected_users.find(user_id);
+            if(user_to_erase != m_connected_users.cend())
+            {
+                m_connected_users.erase(user_id);
+                m_listeners.call(&Listener::connectedUserChanged, *this);
+            }
+        });
+        
+        m_receive_connected_users_signal_cnx = patcher.signal_receive_connected_users.connect([this](std::vector<uint64_t> users){
+            
+            // Todo : make a diff of the changes and notify listeners only if the list really changed.
+            m_connected_users.clear();
+            m_connected_users.insert(users.begin(), users.end());
+            m_listeners.call(&Listener::connectedUserChanged, *this);
+        });
+        
         DocumentManager::connect(patcher,
                                  session.getHost(),
                                  session.getSessionPort(),
@@ -143,12 +169,7 @@ namespace kiwi
     
     size_t PatcherManager::getNumberOfUsers()
     {
-        auto& patcher = getPatcher();
-        auto& user = patcher.getUsers();
-        
-        return std::count_if(user.begin(), user.end(), [](model::Patcher::User const& user){
-            return (!user.removed() && user.getNumberOfViews() > 0);
-        });
+        return m_connected_users.size();
     }
     
     size_t PatcherManager::getNumberOfView()

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherManager.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherManager.h
@@ -87,6 +87,9 @@ namespace kiwi
         //! @brief Returns the number of users connected to the patcher document.
         size_t getNumberOfUsers();
         
+        //! @brief Returns the list of users connected to the patcher document.
+        std::unordered_set<uint64_t> getConnectedUsers();
+        
         //! @brief Returns the number of patcher views.
         size_t getNumberOfView();
         
@@ -180,9 +183,6 @@ namespace kiwi
     struct PatcherManager::Listener
     {
         virtual ~Listener() {};
-        
-        //! @brief Called when the document state changed.
-        virtual void documentStateChanged() {};
         
         //! @brief Called when one or more users are connecting or disconnecting to the Patcher Document.
         virtual void connectedUserChanged(PatcherManager& manager) {};

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherManager.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherManager.h
@@ -31,6 +31,8 @@
 
 #include "../KiwiApp_Network/KiwiApp_DocumentBrowser.h"
 
+#include <unordered_set>
+
 namespace kiwi
 {
     class Instance;
@@ -161,6 +163,12 @@ namespace kiwi
         bool                                        m_need_saving_flag;
         bool                                        m_is_remote;
         DocumentBrowser::Drive::DocumentSession*    m_session {nullptr};
+        
+        flip::SignalConnection                      m_user_connected_signal_cnx;
+        flip::SignalConnection                      m_user_disconnected_signal_cnx;
+        flip::SignalConnection                      m_receive_connected_users_signal_cnx;
+        
+        std::unordered_set<uint64_t>                m_connected_users;
         
         engine::Listeners<Listener>                 m_listeners;
     };

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherView.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherView.h
@@ -28,6 +28,7 @@
 #include "KiwiApp_PatcherViewport.h"
 #include "KiwiApp_PatcherViewHitTester.h"
 #include "KiwiApp_PatcherViewHelper.h"
+#include "KiwiApp_PatcherManager.h"
 
 namespace kiwi
 {
@@ -43,7 +44,10 @@ namespace kiwi
     // ================================================================================ //
     
     //! @brief The juce Patcher Component.
-    class PatcherView : public juce::Component, public juce::ApplicationCommandTarget
+    class PatcherView
+    : public juce::Component
+    , public juce::ApplicationCommandTarget
+    , public PatcherManager::Listener
     {
     public:
         
@@ -138,6 +142,13 @@ namespace kiwi
         
         //! @brief Called internally when the origin of the patcher view changed.
         void originPositionChanged();
+        
+        // ================================================================================ //
+        //                             PATCHER MANAGER LISTENER                             //
+        // ================================================================================ //
+        
+        //! @brief Called when one or more users are connecting or disconnecting to the Patcher Document.
+        void connectedUserChanged(PatcherManager& manager) override;
         
         // ================================================================================ //
         //                                  MODEL OBSERVER                                  //

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherViewHelper.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherViewHelper.h
@@ -21,8 +21,10 @@
 
 #pragma once
 
+#include "flip/Ref.h"
+
 #include <juce_gui_extra/juce_gui_extra.h>
-#include <flip/Ref.h>
+
 #include <set>
 
 namespace kiwi

--- a/Modules/KiwiModel/KiwiModel_Object.h
+++ b/Modules/KiwiModel/KiwiModel_Object.h
@@ -21,12 +21,6 @@
 
 #pragma once
 
-#include <KiwiModel/KiwiModel_Atom.h>
-#include <mutex>
-#include <algorithm>
-#include <exception>
-#include <set>
-
 // ---- Flip headers ---- //
 #include "flip/Bool.h"
 #include "flip/Int.h"
@@ -37,6 +31,14 @@
 #include "flip/Object.h"
 #include "flip/ObjectRef.h"
 #include "flip/Enum.h"
+#include "flip/Signal.h"
+
+#include "KiwiModel_Atom.h"
+
+#include <mutex>
+#include <algorithm>
+#include <exception>
+#include <set>
 
 namespace kiwi
 {

--- a/Modules/KiwiModel/KiwiModel_Patcher.cpp
+++ b/Modules/KiwiModel/KiwiModel_Patcher.cpp
@@ -52,6 +52,10 @@ namespace kiwi
         // ================================================================================ //
         
         Patcher::Patcher()
+        : signal_user_connect(Signal_USER_CONNECT, *this)
+        , signal_user_disconnect(Signal_USER_DISCONNECT, *this)
+        , signal_get_connected_users(Signal_GET_CONNECTED_USERS, *this)
+        , signal_receive_connected_users(Signal_RECEIVE_CONNECTED_USERS, *this)
         {
             // user changes doesn't need to be stored in an history.
             m_users.disable_in_undo();

--- a/Modules/KiwiModel/KiwiModel_Patcher.h
+++ b/Modules/KiwiModel/KiwiModel_Patcher.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "flip/Signal.h"
 #include "KiwiModel_Link.h"
 
 namespace kiwi
@@ -124,6 +125,28 @@ namespace kiwi
             //! therefore, do not use this method while observing the model.
             //! @return The current User.
             User& useSelfUser();
+            
+        public: // signals
+            
+            enum
+            {
+                Signal_USER_CONNECT     = 0,
+                Signal_USER_DISCONNECT,
+                Signal_GET_CONNECTED_USERS,
+                Signal_RECEIVE_CONNECTED_USERS,
+            };
+            
+            // from server to client
+            flip::Signal<uint64_t>              signal_user_connect;
+            
+            // from server to client
+            flip::Signal<uint64_t>              signal_user_disconnect;
+            
+            // from client to server
+            flip::Signal<>                      signal_get_connected_users;
+            
+            // from server to client
+            flip::Signal<std::vector<uint64_t>> signal_receive_connected_users;
             
         public: // internal methods
             

--- a/Modules/KiwiModel/KiwiModel_Patcher.h
+++ b/Modules/KiwiModel/KiwiModel_Patcher.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include "flip/Signal.h"
 #include "KiwiModel_Link.h"
 
 namespace kiwi

--- a/Modules/KiwiModel/KiwiModel_PatcherValidator.h
+++ b/Modules/KiwiModel/KiwiModel_PatcherValidator.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <flip/DocumentValidator.h>
+#include "flip/DocumentValidator.h"
 
 #include "KiwiModel_PatcherUser.h"
 

--- a/Server/Source/KiwiServer_Server.cpp
+++ b/Server/Source/KiwiServer_Server.cpp
@@ -39,19 +39,11 @@ namespace kiwi
         const char* Server::kiwi_file_extension = "kiwi";
         
         Server::Server(uint16_t port, std::string const& backend_directory) :
+        ServerBase(model::DataModel::use(), port),
         m_port(port),
-        m_server(model::DataModel::use(), m_port),
         m_running(false),
         m_backend_directory(backend_directory)
         {
-            using namespace std::placeholders; // for _1, _2 etc.
-            
-            m_server.bind_validator_factory(std::bind(&Server::createValidator, this, _1));
-            m_server.bind_init(std::bind(&Server::initEmptyDocument, this, _1, _2));
-            m_server.bind_read(std::bind(&Server::readSessionBackend, this, _1));
-            m_server.bind_write(std::bind(&Server::writeSessionBackend, this, _1, _2));
-            m_server.bind_authenticate(std::bind(&Server::authenticateUser, this, _1, _2, _3));
-            
             if (m_backend_directory.exists() && !m_backend_directory.isDirectory())
             {
                 throw std::runtime_error("Specified backend directory is a file");
@@ -103,16 +95,6 @@ namespace kiwi
         uint16_t Server::getPort() const noexcept
         {
             return m_port;
-        }
-        
-        uint16_t Server::getNumberOfActiveSessions() const noexcept
-        {
-            return m_server.nbr_sessions();
-        }
-        
-        void Server::process()
-        {
-            m_server.process();
         }
         
         std::unique_ptr<flip::DocumentValidatorBase> Server::createValidator(uint64_t session_id)

--- a/Server/Source/KiwiServer_Server.cpp
+++ b/Server/Source/KiwiServer_Server.cpp
@@ -171,5 +171,18 @@ namespace kiwi
             return converter.str();
         }
         
+        void Server::onConnected(Session& session, uint64_t user_id)
+        {
+            std::cout
+            << "- User " << std::to_string(user_id)
+            << " connected to session: " << hexadecimal_convert(session.identifier()) << '\n';
+        }
+        
+        void Server::onDisconnected(Session& session, uint64_t user_id)
+        {
+            std::cout
+            << "- User " << std::to_string(user_id)
+            << " disconnected from session: " << hexadecimal_convert(session.identifier()) << '\n';
+        }
     }
 }

--- a/Server/Source/KiwiServer_Server.cpp
+++ b/Server/Source/KiwiServer_Server.cpp
@@ -19,8 +19,8 @@
  ==============================================================================
  */
 
-#include <flip/contrib/DataProviderFile.h>
-#include <flip/contrib/DataConsumerFile.h>
+#include "flip/contrib/DataProviderFile.h"
+#include "flip/contrib/DataConsumerFile.h"
 
 #include <KiwiModel/KiwiModel_DataModel.h>
 #include <KiwiModel/KiwiModel_PatcherUser.h>

--- a/Server/Source/KiwiServer_Server.h
+++ b/Server/Source/KiwiServer_Server.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include <flip/contrib/ServerSimple.h>
-#include <flip/BackEndBinary.h>
+#include "flip/contrib/ServerSimple.h"
+#include "flip/BackEndBinary.h"
 
 #include <KiwiModel/KiwiModel_PatcherUser.h>
 

--- a/Server/Source/KiwiServer_Server.h
+++ b/Server/Source/KiwiServer_Server.h
@@ -83,6 +83,12 @@ namespace kiwi
             //! @brief Authenticate a user.
             bool authenticateUser(uint64_t user_id, uint64_t session_id, std::string metadata) override;
             
+            //! @brief Called when a user connects to a document
+            void onConnected(Session& session, uint64_t user_id) override;
+            
+            //! @brief Called when a user has been disconnected from a document
+            void onDisconnected(Session& session, uint64_t user_id) override;
+            
             //! @brief Get the path for a given session.
             juce::File getSessionFile(uint64_t session_id);
             

--- a/Server/Source/KiwiServer_Server.h
+++ b/Server/Source/KiwiServer_Server.h
@@ -28,8 +28,9 @@
 
 #include <juce_core/juce_core.h>
 
-#include <map>
 #include <atomic>
+
+#include "KiwiServer_ServerBase.h"
 
 namespace kiwi
 {
@@ -40,7 +41,7 @@ namespace kiwi
         // ================================================================================ //
         
         //! @brief The Server class.
-        class Server
+        class Server : public ServerBase
         {
         public: // methods
             
@@ -50,13 +51,13 @@ namespace kiwi
             //! @brief Destructor.
             ~Server();
             
-            //! @brief Server process
-            void process();
-            
-            //! @brief Loop that retrieves user input to manager server.
+            //! @brief Run the server.
+            //! @details This will run a loop that call ServerBase::process regularly.
+            //! @see stop
             void run();
             
             //! @brief Stops the server.
+            //! @see Run, isRunning
             void stop();
             
             //! @brief Returns true if the server is running.
@@ -65,25 +66,22 @@ namespace kiwi
             //! @brief Get the server running port
             uint16_t getPort() const noexcept;
             
-            //! @brief Get the number of sessions currently running.
-            uint16_t getNumberOfActiveSessions() const noexcept;
-            
         private: // methods
             
             //! @brief Initialise a new empty patcher
-            std::unique_ptr<flip::DocumentValidatorBase> createValidator(uint64_t session_id);
+            std::unique_ptr<flip::DocumentValidatorBase> createValidator(uint64_t session_id) override;
             
             //! @brief Initialise a new empty patcher
-            void initEmptyDocument(uint64_t session_id, flip::DocumentBase & document);
+            void initEmptyDocument(uint64_t session_id, flip::DocumentBase & document) override;
             
             //! @brief read a session backend.
-            flip::BackEndIR readSessionBackend(uint64_t session_id);
+            flip::BackEndIR readSessionBackend(uint64_t session_id) override;
             
             //! @brief write a session backend.
-            void writeSessionBackend(uint64_t session_id, flip::BackEndIR const& backend);
+            void writeSessionBackend(uint64_t session_id, flip::BackEndIR const& backend) override;
             
             //! @brief Authenticate a user.
-            bool authenticateUser(uint64_t user_id, uint64_t session_id, std::string metadata);
+            bool authenticateUser(uint64_t user_id, uint64_t session_id, std::string metadata) override;
             
             //! @brief Get the path for a given session.
             juce::File getSessionFile(uint64_t session_id);
@@ -96,9 +94,7 @@ namespace kiwi
         private: // variables
             
             const uint16_t                      m_port;
-            flip::ServerSimple                  m_server;
             std::atomic_bool                    m_running;
-            
             juce::File                          m_backend_directory;
             
             static const char*  kiwi_file_extension;

--- a/Server/Source/KiwiServer_Server.h
+++ b/Server/Source/KiwiServer_Server.h
@@ -83,6 +83,9 @@ namespace kiwi
             //! @brief Authenticate a user.
             bool authenticateUser(uint64_t user_id, uint64_t session_id, std::string metadata) override;
             
+            //! @brief Called when a new session has been created.
+            void sessionCreated(Session& session) override;
+            
             //! @brief Called when a user connects to a document
             void onConnected(Session& session, uint64_t user_id) override;
             
@@ -99,9 +102,9 @@ namespace kiwi
             
         private: // variables
             
-            const uint16_t                      m_port;
-            std::atomic_bool                    m_running;
-            juce::File                          m_backend_directory;
+            const uint16_t      m_port;
+            std::atomic_bool    m_running;
+            juce::File          m_backend_directory;
             
             static const char*  kiwi_file_extension;
             

--- a/Server/Source/KiwiServer_ServerBase.cpp
+++ b/Server/Source/KiwiServer_ServerBase.cpp
@@ -1,0 +1,250 @@
+/*
+ ==============================================================================
+ 
+ This file is part of the KIWI library.
+ - Copyright (c) 2014-2016, Pierre Guillot& Eliott Paris.
+ - Copyright (c) 2016-2017, CICM, ANR MUSICOLL, Eliott Paris, Pierre Guillot, Jean Millot.
+ 
+ Permission is granted to use this software under the terms of the GPL v3
+ (or any later version). Details can be found at: www.gnu.org/licenses
+ 
+ KIWI is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ 
+ ------------------------------------------------------------------------------
+ 
+ Contact : cicm.mshparisnord@gmail.com
+ 
+ ==============================================================================
+ */
+
+#include "KiwiServer_ServerBase.h"
+
+#include "flip/DocumentValidatorVoid.h"
+#include "flip/detail/def.h"
+#include "flip/detail/fnc.h"
+
+#include <cassert>
+
+namespace kiwi
+{
+    namespace server
+    {
+        // ================================================================================ //
+        //                                   SERVER SESSION                                 //
+        // ================================================================================ //
+        
+        ServerBase::Session::Session(Session && rhs)
+        : m_parent(rhs.m_parent)
+        , m_identifier(std::move(rhs.m_identifier))
+        , m_validator_uptr(std::move(rhs.m_validator_uptr))
+        , m_document_uptr(std::move(rhs.m_document_uptr))
+        {
+            ;
+        }
+        
+        ServerBase::Session::Session(ServerBase& parent,
+                                     uint64_t identifier,
+                                     std::unique_ptr<flip::DocumentServer> && document_uptr,
+                                     std::unique_ptr<flip::DocumentValidatorBase> && validator_uptr)
+        : m_parent(parent)
+        , m_identifier(identifier)
+        , m_validator_uptr(std::move(validator_uptr))
+        , m_document_uptr(std::move(document_uptr))
+        {
+            ;
+        }
+        
+        uint64_t ServerBase::Session::identifier() const
+        {
+            return m_identifier;
+        }
+
+        flip::DocumentServer& ServerBase::Session::document()
+        {
+            return *m_document_uptr;
+        }
+        
+        void ServerBase::Session::write()
+        {
+            m_parent.writeSession(document(), identifier());
+        }
+        
+        // ================================================================================ //
+        //                                      SERVER                                      //
+        // ================================================================================ //
+        
+        ServerBase::ServerBase(flip::DataModelBase const& data_model, uint16_t port)
+        : m_data_model(data_model)
+        , m_port(*this, port)
+        , m_sessions()
+        {
+        }
+
+        ServerBase::~ServerBase()
+        {
+            for(auto& pair : m_sessions)
+            {
+                auto& server = pair.second.document();
+                
+                auto ports = server.ports();
+                
+                for(auto* port_ptr : ports)
+                {
+                    server.port_factory_remove(*port_ptr);
+                    port_ptr->impl_bind(*this);
+                }
+            }
+            
+            m_sessions.clear();
+            
+            m_port.reset();
+        }
+        
+        void ServerBase::process()
+        {
+            m_port.process();
+        }
+        
+        size_t ServerBase::getNumberOfSessions() const
+        {
+            return m_sessions.size();
+        }
+        
+        void ServerBase::writeSession(flip::DocumentServer& server, uint64_t session_id)
+        {
+            auto backend = server.write();
+            writeSessionBackend(session_id, backend);
+        }
+        
+        void ServerBase::port_factory_add(flip::PortBase& port)
+        {
+            port.impl_bind(*this);
+        }
+        
+        void ServerBase::port_factory_remove(flip::PortBase& port)
+        {
+            port.impl_activate(false);
+            
+            bool was_attached_flag = false;
+            
+            auto it = m_sessions.begin();
+            const auto it_end = m_sessions.end();
+            
+            for(; it != it_end ;)
+            {
+                auto it_next = it;
+                ++it_next;
+                
+                auto session_id = it->first;
+                auto& document_server = it->second.document();
+                const auto& ports = document_server.ports();
+                
+                if(ports.find(&port) != ports.end())
+                {
+                    was_attached_flag = true;
+                    document_server.port_factory_remove(port);
+                    
+                    if(ports.empty())
+                    {
+                        writeSession(document_server, session_id);
+                        
+                        m_sessions.erase(it);
+                    }
+                    
+                    break;
+                }
+                
+                it = it_next;
+            }
+            
+            if(!was_attached_flag)
+            {
+                port.impl_unbind(*this);
+            }
+        }
+        
+        void ServerBase::port_greet(flip::PortBase& from)
+        {
+            if(!authenticateUser(from.user(), from.session(), from.metadata()))
+            {
+                throw std::runtime_error("authentication failed");
+            }
+            
+            auto session_id = from.session();
+            auto it = m_sessions.find(session_id);
+            
+            if(it == m_sessions.end())
+            {
+                it = create_session(session_id);
+            }
+            
+            assert(it != m_sessions.end());
+            
+            auto& document_server = it->second.document();
+            
+            // rebind
+            from.impl_unbind(*this);
+            document_server.port_factory_add(from);
+            
+            // forward
+            document_server.port_greet(from);
+        }
+        
+        void ServerBase::port_commit(flip::PortBase& /* from */, const flip::Transaction& /* tx */)
+        {
+            // nothing
+        }
+        
+        void ServerBase::port_squash(flip::PortBase& /* from */, const flip::TxIdRange& /* range */, const flip::Transaction& /* tx */)
+        {
+            // nothing
+        }
+
+        void ServerBase::port_push(flip::PortBase& /* from */, const flip::Transaction& /* tx */)
+        {
+            // port was rebound in greet
+            flip_FATAL;
+        }
+
+        void ServerBase::port_signal(flip::PortBase& /* from */, const flip::SignalData& /* data */)
+        {
+            // port was rebound in greet
+            flip_FATAL;
+        }
+        
+        ServerBase::SessionMap::iterator ServerBase::create_session(uint64_t session_id)
+        {
+            auto validator_uptr = createValidator(session_id);
+            
+            auto document_uptr = std::make_unique<flip::DocumentServer>(m_data_model,
+                                                                        *validator_uptr,
+                                                                        session_id);
+            
+            load_session(*document_uptr, session_id);
+            
+            auto && pair = std::make_pair(session_id, Session(*this, session_id,
+                                                              std::move(document_uptr),
+                                                              std::move(validator_uptr)));
+            
+            return m_sessions.insert(std::move(pair)).first;
+        }
+        
+        void ServerBase::load_session(flip::DocumentServer& server, uint64_t session_id)
+        {
+            flip::BackEndIR backend(readSessionBackend(session_id));
+            
+            if(backend.empty())
+            {
+                initEmptyDocument(session_id, server);
+            }
+            else
+            {
+                server.read(backend);
+            }
+            
+            server.commit();
+        }
+    }
+}

--- a/Server/Source/KiwiServer_ServerBase.cpp
+++ b/Server/Source/KiwiServer_ServerBase.cpp
@@ -137,14 +137,18 @@ namespace kiwi
                 auto it_next = it;
                 ++it_next;
                 
-                auto session_id = it->first;
-                auto& document_server = it->second.document();
+                auto& session = it->second;
+                auto session_id = session.identifier();
+                auto& document_server = session.document();
                 const auto& ports = document_server.ports();
                 
                 if(ports.find(&port) != ports.end())
                 {
                     was_attached_flag = true;
                     document_server.port_factory_remove(port);
+                    
+                    // notify
+                    onDisconnected(session, port.user());
                     
                     if(ports.empty())
                     {
@@ -182,7 +186,8 @@ namespace kiwi
             
             assert(it != m_sessions.end());
             
-            auto& document_server = it->second.document();
+            auto& session = it->second;
+            auto& document_server = session.document();
             
             // rebind
             from.impl_unbind(*this);
@@ -190,6 +195,9 @@ namespace kiwi
             
             // forward
             document_server.port_greet(from);
+            
+            // notify
+            onConnected(session, from.user());
         }
         
         void ServerBase::port_commit(flip::PortBase& /* from */, const flip::Transaction& /* tx */)

--- a/Server/Source/KiwiServer_ServerBase.h
+++ b/Server/Source/KiwiServer_ServerBase.h
@@ -79,6 +79,12 @@ namespace kiwi
             //! @brief Authenticate a user.
             virtual bool authenticateUser(uint64_t user_id, uint64_t session_id, std::string metadata) = 0;
             
+            //! @brief Called when a user connects to a document
+            virtual void onConnected(Session& session, uint64_t user_id) {};
+            
+            //! @brief Called when a user has been disconnected from a document
+            virtual void onDisconnected(Session& session, uint64_t user_id) {};
+            
         private: // methods
             
             // PortFactoryListener

--- a/Server/Source/KiwiServer_ServerBase.h
+++ b/Server/Source/KiwiServer_ServerBase.h
@@ -27,6 +27,7 @@
 
 #include "flip/detail/DocumentValidatorBase.h"
 #include "flip/detail/BackEndBase.h"
+#include "flip/Signal.h"
 
 #include <map>
 #include <memory>
@@ -79,13 +80,19 @@ namespace kiwi
             //! @brief Authenticate a user.
             virtual bool authenticateUser(uint64_t user_id, uint64_t session_id, std::string metadata) = 0;
             
-            //! @brief Called when a user connects to a document
+            //! @brief Called when a new Session has been created.
+            virtual void sessionCreated(Session& session) {};
+            
+            //! @brief Called when a user connects to a document.
             virtual void onConnected(Session& session, uint64_t user_id) {};
             
-            //! @brief Called when a user has been disconnected from a document
+            //! @brief Called when a user has been disconnected from a document.
             virtual void onDisconnected(Session& session, uint64_t user_id) {};
             
         private: // methods
+            
+            SessionMap::iterator create_session(uint64_t session_id);
+            void load_session(flip::DocumentServer & server, uint64_t session_id);
             
             // PortFactoryListener
             virtual void port_factory_add(flip::PortBase & port) override;
@@ -108,9 +115,6 @@ namespace kiwi
                                      const flip::SignalData & data) override;
             
         private: // variables
-            
-            SessionMap::iterator create_session(uint64_t session_id);
-            void load_session(flip::DocumentServer & server, uint64_t session_id);
             
             const flip::DataModelBase&      m_data_model;
             flip::PortTransportServerTcp    m_port;
@@ -157,12 +161,20 @@ namespace kiwi
             //! @brief Write the session.
             void write();
             
+            //! @brief Returns a list of connected users.
+            std::vector<uint64_t> getConnectedUsers();
+            
+            //! @brief Store the signal connection in the session.
+            void storeSignalConnection(flip::SignalConnection && cnx);
+            
         private: // variables
             
             ServerBase&                                     m_parent;
             const uint64_t                                  m_identifier;
             std::unique_ptr<flip::DocumentValidatorBase>    m_validator_uptr;
             std::unique_ptr<flip::DocumentServer>           m_document_uptr;
+            
+            std::vector<flip::SignalConnection>             m_signal_connections;
             
         private: // variables
             

--- a/Server/Source/KiwiServer_ServerBase.h
+++ b/Server/Source/KiwiServer_ServerBase.h
@@ -1,0 +1,169 @@
+/*
+ ==============================================================================
+ 
+ This file is part of the KIWI library.
+ - Copyright (c) 2014-2016, Pierre Guillot & Eliott Paris.
+ - Copyright (c) 2016-2017, CICM, ANR MUSICOLL, Eliott Paris, Pierre Guillot, Jean Millot.
+ 
+ Permission is granted to use this software under the terms of the GPL v3
+ (or any later version). Details can be found at: www.gnu.org/licenses
+ 
+ KIWI is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ 
+ ------------------------------------------------------------------------------
+ 
+ Contact : cicm.mshparisnord@gmail.com
+ 
+ ==============================================================================
+ */
+
+#pragma once
+
+#include "flip/config.h"
+#include "flip/contrib/transport_tcp/PortTransportServerTcp.h"
+#include "flip/DocumentServer.h"
+
+#include "flip/detail/DocumentValidatorBase.h"
+#include "flip/detail/BackEndBase.h"
+
+#include <map>
+#include <memory>
+
+namespace kiwi
+{
+    namespace server
+    {
+        // ================================================================================ //
+        //                                      SERVER                                      //
+        // ================================================================================ //
+        
+        class ServerBase : public flip::PortFactoryListener, public flip::PortListener
+        {
+        public: // methods
+            
+            class Session;
+            using SessionMap = std::map<uint64_t, Session>;
+            
+            //! @brief Constructor.
+            ServerBase(flip::DataModelBase const& data_model, uint16_t port);
+            
+            //! @brief Destructor.
+            virtual ~ServerBase();
+            
+            //! @brief Server process
+            //! @details Must be called regularly.
+            void process();
+            
+            //! @brief Get the number of sessions currently running.
+            size_t getNumberOfSessions() const;
+            
+            //! @brief Write the Session
+            void writeSession(flip::DocumentServer& server, uint64_t session_id);
+            
+        protected: // methods
+            
+            //! @brief Create a document validator.
+            virtual std::unique_ptr<flip::DocumentValidatorBase> createValidator(uint64_t session_id) = 0;
+            
+            //! @brief Initialise a new empty document.
+            virtual void initEmptyDocument(uint64_t session_id, flip::DocumentBase & document) = 0;
+            
+            //! @brief read a session backend.
+            virtual flip::BackEndIR readSessionBackend(uint64_t session_id) = 0;
+            
+            //! @brief write a session backend.
+            virtual void writeSessionBackend(uint64_t session_id, flip::BackEndIR const& backend) = 0;
+            
+            //! @brief Authenticate a user.
+            virtual bool authenticateUser(uint64_t user_id, uint64_t session_id, std::string metadata) = 0;
+            
+        private: // methods
+            
+            // PortFactoryListener
+            virtual void port_factory_add(flip::PortBase & port) override;
+            virtual void port_factory_remove(flip::PortBase & port) override;
+            
+            // PortListener
+            virtual void port_greet(flip::PortBase& from) override;
+            
+            virtual void port_commit(flip::PortBase& from,
+                                     flip::Transaction const & tx) override;
+            
+            virtual void port_squash(flip::PortBase& from,
+                                     flip::TxIdRange const& range,
+                                     flip::Transaction const& tx) override;
+            
+            virtual void port_push(flip::PortBase& from,
+                                   flip::Transaction const& tx) override;
+            
+            virtual void port_signal(flip::PortBase& from,
+                                     const flip::SignalData & data) override;
+            
+        private: // variables
+            
+            SessionMap::iterator create_session(uint64_t session_id);
+            void load_session(flip::DocumentServer & server, uint64_t session_id);
+            
+            const flip::DataModelBase&      m_data_model;
+            flip::PortTransportServerTcp    m_port;
+            SessionMap                      m_sessions;
+            
+        private: // deleted methods
+            
+            ServerBase() = delete;
+            ServerBase(const ServerBase & rhs) = delete;
+            ServerBase(ServerBase && rhs) = delete;
+            ServerBase& operator =(const ServerBase & rhs) = delete;
+            ServerBase& operator =(ServerBase && rhs) = delete;
+            bool operator ==(const ServerBase & rhs) const = delete;
+            bool operator !=(const ServerBase & rhs) const = delete;
+        };
+        
+        // ================================================================================ //
+        //                                   SERVER SESSION                                 //
+        // ================================================================================ //
+        
+        class ServerBase::Session
+        {
+        public: // methods
+            
+            //! @brief Constructor.
+            //! @details Create a Session by moving another Session.
+            Session(Session && rhs);
+            
+            //! @brief Constructor.
+            Session(ServerBase& parent,
+                    uint64_t session_id,
+                    std::unique_ptr<flip::DocumentServer> && document_uptr,
+                    std::unique_ptr<flip::DocumentValidatorBase> && validator_uptr);
+            
+            //! @brief Destructor.
+            virtual ~Session() = default;
+            
+            //! @brief Get the Session identifier.
+            uint64_t identifier() const;
+            
+            //! @brief Get the document.
+            flip::DocumentServer& document();
+            
+            //! @brief Write the session.
+            void write();
+            
+        private: // variables
+            
+            ServerBase&                                     m_parent;
+            const uint64_t                                  m_identifier;
+            std::unique_ptr<flip::DocumentValidatorBase>    m_validator_uptr;
+            std::unique_ptr<flip::DocumentServer>           m_document_uptr;
+            
+        private: // variables
+            
+            Session() = delete;
+            Session(const Session & rhs) = delete;
+            Session& operator = (const Session & rhs) = delete;
+            Session& operator = (Session && rhs) = delete;
+        };
+    }
+}

--- a/Test/Model/test_PatcherValidator.cpp
+++ b/Test/Model/test_PatcherValidator.cpp
@@ -21,10 +21,10 @@
 
 #include "../catch.hpp"
 
-#include <flip/Document.h>
-#include <flip/DocumentServer.h>
-#include <flip/PortDirect.h>
-#include <flip/CarrierDirect.h>
+#include "flip/Document.h"
+#include "flip/DocumentServer.h"
+#include "flip/PortDirect.h"
+#include "flip/CarrierDirect.h"
 
 #include <KiwiModel/KiwiModel_DataModel.h>
 #include <KiwiModel/KiwiModel_PatcherUser.h>


### PR DESCRIPTION
- Add our own ServerBase class based on the flip::ServerSimple one
- Broadcast a signal to clients when a user is connected or disconnected.
- Hide disconnected users selection
- Add a UsersItemComponent in the patcher toolbar that shows the number of connected users per document.