### PR TITLE
Dollar and Comma syntax support

### DIFF
--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_MessageView.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_MessageView.cpp
@@ -128,16 +128,23 @@ namespace kiwi {
     
     void MessageView::textChanged()
     {
-        juce::Label & label = getLabel();
+        juce::Label& label = getLabel();
         
-        const int text_width = label.getFont().getStringWidth(label.getText());
+        // Parse text and convert it back to string to display the formated version.
+        const auto atoms = tool::AtomHelper::parse(label.getText().toStdString(),
+                                                   tool::AtomHelper::ParsingFlags::Comma
+                                                   | tool::AtomHelper::ParsingFlags::Dollar);
         
+        auto formatted_text = tool::AtomHelper::toString(atoms);
+        const int text_width = label.getFont().getStringWidth(formatted_text);
         model::Object & model = getModel();
-        
         model.setWidth(text_width + 16);
         
+        // set the attribute and label text with formated text
+        getLabel().setText(formatted_text, juce::NotificationType::dontSendNotification);
+        
         setAttribute("text", tool::Parameter(tool::Parameter::Type::String,
-                                             {label.getText().toStdString()}));
+                                             {std::move(formatted_text)}));
     }
     
     juce::TextEditor* MessageView::createdTextEditor()

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_ObjectView.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_ObjectView.cpp
@@ -102,8 +102,6 @@ namespace kiwi
     
     void ObjectView::drawOutline(juce::Graphics & g)
     {
-        juce::Rectangle<int> outline = getOutline();
-        
         g.drawRect(getOutline(), m_border_size);
     }
     

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Delay.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Delay.cpp
@@ -69,7 +69,7 @@ namespace kiwi
             {
                 if (index == 0)
                 {
-                    if(args[0].isString() && args[0].getString() == "bang")
+                    if(args[0].isBang())
                     {
                         getScheduler().schedule(m_task, m_delay);
                     }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Hub.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Hub.cpp
@@ -54,7 +54,7 @@ namespace kiwi { namespace engine {
     {
         if (name == "message")
         {
-            send(0,{tool::AtomHelper::parse(parameter[0].getString())});
+            send(0, tool::AtomHelper::parse(parameter[0].getString()));
         }
     }
     
@@ -62,7 +62,9 @@ namespace kiwi { namespace engine {
     {
         if (index == 0 && !args.empty())
         {
-            setAttribute("message", tool::Parameter(tool::Parameter::Type::String, {tool::AtomHelper::toString(args)}));
+            setAttribute("message",
+                         tool::Parameter(tool::Parameter::Type::String,
+                                         {tool::AtomHelper::toString(args)}));
         }
     }
     

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Loadmess.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Loadmess.cpp
@@ -46,7 +46,7 @@ namespace kiwi { namespace engine {
     
     void Loadmess::receive(size_t index, std::vector<tool::Atom> const& args)
     {
-        if (!args.empty() && args[0].isString() && args[0].getString() == "bang")
+        if (!args.empty() && args[0].isBang())
         {
             send(0ul, m_args);
         }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Message.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Message.cpp
@@ -40,12 +40,12 @@ namespace kiwi { namespace engine {
         return std::make_unique<Message>(model, patcher);
     }
     
-    Message::Message(model::Object const& object_model, Patcher& patcher):
-    Object(object_model, patcher),
-    m_text(object_model.getAttribute("text")[0].getString()),
-    m_connection(object_model.getSignal<>(model::Message::Signal::outputMessage)
-                 .connect(std::bind(&Message::outputMessage, this)))
+    Message::Message(model::Object const& object_model, Patcher& patcher)
+    : Object(object_model, patcher)
+    , m_connection(object_model.getSignal<>(model::Message::Signal::outputMessage)
+                   .connect(std::bind(&Message::outputMessage, this)))
     {
+        attributeChanged("text", object_model.getAttribute("text"));
     }
     
     
@@ -57,7 +57,7 @@ namespace kiwi { namespace engine {
     {
         defer([this]()
         {
-            send(0, tool::AtomHelper::parse(m_text));
+            sendMessages();
         });
     }
     
@@ -65,7 +65,13 @@ namespace kiwi { namespace engine {
     {
         if (name == "text")
         {
-            m_text = parameter[0].getString();
+            tool::Atom null;
+            for(auto& input_args : m_input_args)
+            {
+                input_args = null;
+            }
+            
+            prepareMessagesForText(parameter[0].getString());
         }
     }
     
@@ -73,7 +79,90 @@ namespace kiwi { namespace engine {
     {
         if (index == 0 && !args.empty())
         {
-            send(0, tool::AtomHelper::parse(m_text));;
+            if(!args[0].isBang())
+            {
+                for(size_t i = 0; i <= 9; i++)
+                {
+                    if(i < args.size())
+                    {
+                        m_input_args[i] = args[i];
+                    }
+                }
+            }
+            
+            sendMessages();
+        }
+    }
+    
+    void Message::prepareMessagesForText(std::string const& text)
+    {
+        static const int flags = (0
+                                  | tool::AtomHelper::ParsingFlags::Comma
+                                  | tool::AtomHelper::ParsingFlags::Dollar);
+        
+        auto atoms = tool::AtomHelper::parse(text, flags);
+        
+        m_messages.clear();
+        if(!atoms.empty())
+        {
+            std::vector<tool::Atom> atom_sequence;
+            bool dollar_flag = false;
+            
+            for(auto&& atom : atoms)
+            {
+                if(atom.isComma())
+                {
+                    if(!atom_sequence.empty())
+                    {
+                        m_messages.emplace_back(std::move(atom_sequence),
+                                                dollar_flag);
+                        atom_sequence.clear();
+                        dollar_flag = false;
+                    }
+                }
+                else
+                {
+                    if(atom.isDollar())
+                    {
+                        dollar_flag = true;
+                    }
+                    
+                    atom_sequence.emplace_back(std::move(atom));
+                }
+            }
+            
+            if(!atom_sequence.empty())
+            {
+                m_messages.emplace_back(std::move(atom_sequence),
+                                        dollar_flag);
+            }
+        }
+    }
+    
+    void Message::sendMessages()
+    {
+        for(auto const& message : m_messages)
+        {
+            if(message.has_dollar)
+            {
+                std::vector<tool::Atom> atoms = message.atoms;
+                
+                for(auto& atom : atoms)
+                {
+                    if(atom.isDollar())
+                    {
+                        const size_t index = atom.getDollarIndex() - 1;
+                        auto& atom_arg = m_input_args[index];
+                        atom = !atom_arg.isNull() ? atom_arg : 0;
+                    }
+                }
+                
+                send(0, atoms);
+            }
+            else
+            {
+                send(0, message.atoms);
+            }
         }
     }
     

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Message.h
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Message.h
@@ -23,6 +23,8 @@
 
 #include <KiwiEngine/KiwiEngine_Object.h>
 
+#include <array>
+
 namespace kiwi { namespace engine {
     
     // ================================================================================ //
@@ -48,10 +50,26 @@ namespace kiwi { namespace engine {
         static std::unique_ptr<Object> create(model::Object const& model, Patcher& patcher);
 
     private: // members
-
-        std::string             m_text;
-        flip::SignalConnection  m_connection;
         
+        void sendMessages();
+        void prepareMessagesForText(std::string const& text);
+
+        flip::SignalConnection      m_connection;
+        std::array<tool::Atom, 10>  m_input_args {};
+        
+        struct Sequence
+        {
+            Sequence(std::vector<tool::Atom>&& _atoms, bool _has_dollar)
+            : atoms(_atoms), has_dollar(_has_dollar)
+            {}
+            
+            ~Sequence() = default;
+            
+            const std::vector<tool::Atom> atoms {};
+            const bool has_dollar = false;
+        };
+        
+        std::vector<Sequence> m_messages {};
     };
     
 }}

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Number.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Number.cpp
@@ -76,7 +76,7 @@ namespace kiwi { namespace engine {
             }
             else if (args[0].isString())
             {
-                if (args[0].getString() == "bang")
+                if (args[0].isBang())
                 {
                     outputValue();
                 }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Operator.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Operator.cpp
@@ -54,7 +54,7 @@ namespace kiwi { namespace engine {
                     m_lhs = args[0].getFloat();
                     bang();
                 }
-                else if(args[0].getString() == "bang")
+                else if(args[0].isBang())
                 {
                     bang();
                 }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Pack.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Pack.cpp
@@ -51,7 +51,8 @@ namespace kiwi { namespace engine {
     
     void Pack::receive(size_t index, std::vector<tool::Atom> const& args)
     {
-        if (args[0].getString() != "bang")
+        const bool is_bang = args[0].isBang();
+        if (!is_bang)
         {
             switch (m_list[index].getType())
             {
@@ -70,14 +71,11 @@ namespace kiwi { namespace engine {
                     m_list[index] = args[0].getString();
                     break;
                 }
-                case tool::Atom::Type::Null:
-                {
-                    break;
-                }
+                default: break;
             }
         }
         
-        if (index == 0 && args[0].isString() && args[0].getString() == "bang")
+        if (index == 0 && is_bang)
         {
             output_list();
         }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Print.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Print.cpp
@@ -71,7 +71,8 @@ namespace kiwi { namespace engine {
     {
         if(!args.empty())
         {
-            post(m_name + " \xe2\x80\xa2 " + tool::AtomHelper::toString(args));
+            // do not include quotes in printed atoms
+            post(m_name + " \xe2\x80\xa2 " + tool::AtomHelper::toString(args, false));
         }
     }
     

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Random.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Random.cpp
@@ -65,7 +65,7 @@ namespace kiwi { namespace engine {
     {
         if (index == 0)
         {
-            if (args[0].isString() && args[0].getString() == "bang")
+            if (args[0].isBang())
             {
                 send(0, {m_random_distribution(m_random_generator)});
             }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Scale.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Scale.cpp
@@ -73,7 +73,7 @@ namespace kiwi { namespace engine {
                 m_value = args[0].getFloat();
                 send(0, {scaleValue()});
             }
-            else if (args[0].isString() && args[0].getString() == "bang")
+            else if (args[0].isBang())
             {
                 send(0, {scaleValue()});
             }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Slider.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Slider.cpp
@@ -88,7 +88,7 @@ namespace kiwi { namespace engine {
                     setParameter("value", tool::Parameter(tool::Parameter::Type::Float, {args[1].getFloat()}));
                 }
             }
-            else if (args[0].isString() && args[0].getString() == "bang")
+            else if (args[0].isBang())
             {
                 send(0, {m_value});
             }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_SnapshotTilde.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_SnapshotTilde.cpp
@@ -48,7 +48,7 @@ namespace kiwi { namespace engine {
     {
         if (index == 0 && !args.empty())
         {
-            if(args[0].getString() == "bang")
+            if(args[0].isBang())
             {
                 send(0, {m_value.load()});
             }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Toggle.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Toggle.cpp
@@ -76,7 +76,7 @@ namespace kiwi { namespace engine {
             {
                 if(args[0].isString())
                 {
-                    if (args[0].getString() == "bang")
+                    if (args[0].isBang())
                     {
                         send(0, {!m_is_on});
                         setParameter("value", tool::Parameter(tool::Parameter::Type::Int, {!m_is_on}));

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Trigger.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Trigger.cpp
@@ -103,56 +103,6 @@ namespace kiwi { namespace engine {
         }
         
         return triggers;
-            
-            /*
-            trigger_fn_t test = trigger_fn_factory(atom);
-            
-            triggers.emplace_back([atom](std::vector<Atom> const& args) {
-                
-                if(atom.isNumber())
-                {
-                    const auto value = atom.isInt() ? atom.getInt() : atom.getFloat();
-                    return std::vector<Atom>{{value}};
-                }
-                
-                const auto str = atom.getString();
-                
-                if(str.empty())
-                {
-                   return std::vector<Atom>();
-                }
-                
-                if(str == "b" || str == "bang")
-                {
-                    return std::vector<Atom>{{"bang"}};
-                }
-                
-                if(str == "i" || str == "int")
-                {
-                    return std::vector<Atom>{{args[0].getInt()}};
-                }
-                
-                if(str == "f" || str == "float")
-                {
-                    return std::vector<Atom>{{args[0].getFloat()}};
-                }
-                
-                if(str == "s" || str == "symbol")
-                {
-                    return args;
-                }
-                
-                if(str == "l" || str == "list")
-                {
-                    return args;
-                }
-                
-                return std::vector<Atom>{{str}};
-                
-            });
-         
-        }
-             */
     }
     
     void Trigger::receive(size_t, std::vector<tool::Atom> const& args)

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Unpack.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Unpack.cpp
@@ -54,7 +54,7 @@ namespace kiwi { namespace engine {
     
     void Unpack::receive(size_t index, std::vector<tool::Atom> const& args)
     {
-        if (args[0].getString() == "bang")
+        if (args[0].isBang())
         {
             output_list();
         }
@@ -62,7 +62,7 @@ namespace kiwi { namespace engine {
         {
             for (int i = std::max(m_list.size() - 1, args.size() - 1); i >= 0; --i)
             {
-                if (args[i].getString() != "bang")
+                if (!args[i].isBang())
                 {
                     switch (m_list[i].getType())
                     {
@@ -87,10 +87,7 @@ namespace kiwi { namespace engine {
                             }
                             break;
                         }
-                        case tool::Atom::Type::Null:
-                        {
-                            break;
-                        }
+                        default: break;
                     }
                 }
                 else if (i > 0)

--- a/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Pack.cpp
+++ b/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Pack.cpp
@@ -62,35 +62,19 @@ namespace kiwi { namespace model {
         }
         else if (is_inlet)
         {
-            std::vector<tool::Atom> const& args = getArguments();
+            auto const& args = getArguments();
             
-            std::string type = "";
-            
-            switch (args[index].getType())
-            {
-                case tool::Atom::Type::Float:
+            const std::string type_str = [atom = args[index]]() {
+                switch(atom.getType())
                 {
-                    type = "float";
-                    break;
+                    case tool::Atom::Type::Int: return "int";
+                    case tool::Atom::Type::Float: return "float";
+                    case tool::Atom::Type::String: return "symbol";
+                    default: return "null";
                 }
-                case tool::Atom::Type::Int:
-                {
-                    type = "int";
-                    break;
-                }
-                case tool::Atom::Type::String:
-                {
-                    type = "symbol";
-                    break;
-                }
-                case tool::Atom::Type::Null:
-                {
-                    type = "void";
-                    break;
-                }
-            }
-            
-            return type + "to be element" + std::to_string(index + 1) + " int list";
+            }();
+
+            return type_str + " atom " + std::to_string(index + 1) + " in list";
         }
         
         return {};

--- a/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Unpack.cpp
+++ b/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Unpack.cpp
@@ -64,33 +64,17 @@ namespace kiwi { namespace model {
         {
             std::vector<tool::Atom> const& args = getArguments();
             
-            std::string type = "";
+            const std::string type_str = [atom = args[index]]() {
+                switch(atom.getType())
+                {
+                    case tool::Atom::Type::Int: return "int";
+                    case tool::Atom::Type::Float: return "float";
+                    case tool::Atom::Type::String: return "symbol";
+                    default: return "null";
+                }
+            }();
             
-            switch (args[index].getType())
-            {
-                case tool::Atom::Type::Float:
-                {
-                    type = "float";
-                    break;
-                }
-                case tool::Atom::Type::Int:
-                {
-                    type = "int";
-                    break;
-                }
-                case tool::Atom::Type::String:
-                {
-                    type = "symbol";
-                    break;
-                }
-                case tool::Atom::Type::Null:
-                {
-                    type = "void";
-                    break;
-                }
-            }
-            
-            return "element " + std::to_string(index + 1) + " in list of type " + type;
+            return "element " + std::to_string(index + 1) + " in list (" + type_str + ")";
         }
 
         

--- a/Modules/KiwiTool/KiwiTool_Atom.cpp
+++ b/Modules/KiwiTool/KiwiTool_Atom.cpp
@@ -1,0 +1,657 @@
+/*
+ ==============================================================================
+ 
+ This file is part of the KIWI library.
+ - Copyright (c) 2014-2016, Pierre Guillot & Eliott Paris.
+ - Copyright (c) 2016-2017, CICM, ANR MUSICOLL, Eliott Paris, Pierre Guillot, Jean Millot.
+ 
+ Permission is granted to use this software under the terms of the GPL v3
+ (or any later version). Details can be found at: www.gnu.org/licenses
+ 
+ KIWI is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ 
+ ------------------------------------------------------------------------------
+ 
+ Contact : cicm.mshparisnord@gmail.com
+ 
+ ==============================================================================
+ */
+
+#include <KiwiTool/KiwiTool_Atom.h>
+
+namespace kiwi { namespace tool {
+    
+    // ================================================================================ //
+    //                                      ATOM                                        //
+    // ================================================================================ //
+    
+    Atom::Atom() noexcept
+    : m_type(Type::Null)
+    , m_value()
+    {
+        ;
+    }
+    
+    Atom::Atom(const bool value) noexcept
+    : m_type(Type::Int)
+    , m_value(value ? int_t(1) : int_t(0))
+    {
+        ;
+    }
+    
+    Atom::Atom(const int value) noexcept
+    : m_type(Type::Int)
+    , m_value(static_cast<int_t>(value))
+    {
+        ;
+    }
+    
+    Atom::Atom(const long value) noexcept
+    : m_type(Type::Int)
+    , m_value(static_cast<int_t>(value))
+    {
+        ;
+    }
+    
+    Atom::Atom(const long long value) noexcept
+    : m_type(Type::Int)
+    , m_value(static_cast<int_t>(value))
+    {
+        ;
+    }
+    
+    Atom::Atom(const float value) noexcept
+    : m_type(Type::Float)
+    , m_value(static_cast<float_t>(value))
+    {
+        ;
+    }
+    
+    Atom::Atom(const double value) noexcept
+    : m_type(Type::Float)
+    , m_value(static_cast<float_t>(value))
+    {
+        ;
+    }
+    
+    Atom::Atom(string_t const& sym)
+    : m_type(Type::String)
+    , m_value(sym)
+    {
+        ;
+    }
+    
+    Atom::Atom(string_t&& sym)
+    : m_type(Type::String)
+    , m_value(std::move(sym))
+    {
+        ;
+    }
+    
+    Atom::Atom(char const* sym)
+    : m_type(Type::String)
+    , m_value(std::move(sym))
+    {
+        ;
+    }
+    
+    Atom Atom::Comma()
+    {
+        Atom atom;
+        atom.m_type = Type::Comma;
+        return atom;
+    }
+    
+    Atom Atom::Dollar(int_t index)
+    {
+        assert((index > 0 && index <= 9));
+        
+        Atom atom(index);
+        atom.m_type = Type::Dollar;
+        return (index > 0 && index <= 9) ? atom : Atom();
+    }
+    
+    Atom::Atom(Atom const& other)
+    : m_type(other.m_type)
+    {
+        switch(m_type)
+        {
+            case Type::Int:
+            case Type::Dollar:
+            {
+                m_value = other.m_value.int_v;
+                break;
+            }
+            case Type::Float:
+            {
+                m_value = other.m_value.float_v;
+                break;
+            }
+            case Type::String:
+            {
+                assert(other.m_value.string_v != nullptr);
+                m_value = *other.m_value.string_v;
+                break;
+            }
+            case Type::Comma:
+            {
+                break;
+            }
+                
+            default: break;
+        }
+    }
+    
+    Atom::Atom(Atom&& other)
+    : m_type(std::move(other.m_type))
+    , m_value(std::move(other.m_value))
+    {
+        // leave the other as a Null value Atom
+        other.m_type = Type::Null;
+        other.m_value = {};
+    }
+    
+    Atom::~Atom()
+    {
+        if(isString())
+        {
+            std::allocator<string_t> alloc;
+            alloc.destroy(m_value.string_v);
+            alloc.deallocate(m_value.string_v, 1);
+        }
+    }
+    
+    Atom& Atom::operator=(Atom const& other)
+    {
+        if(!other.isString())
+        {
+            if(isString())
+            {
+                std::allocator<string_t> alloc;
+                alloc.destroy(m_value.string_v);
+                alloc.deallocate(m_value.string_v, 1);
+            }
+            
+            m_value = other.m_value;
+        }
+        else
+        {
+            if(isString())
+            {
+                *m_value.string_v = *other.m_value.string_v;
+            }
+            else
+            {
+                m_value.string_v = create_string_pointer(*other.m_value.string_v);
+            }
+        }
+        
+        m_type = other.m_type;
+        
+        return *this;
+    }
+    
+    Atom& Atom::operator=(Atom&& other) noexcept
+    {
+        std::swap(m_type, other.m_type);
+        std::swap(m_value, other.m_value);
+        return *this;
+    }
+    // ================================================================================ //
+    //                                   Type Getters                                   //
+    // ================================================================================ //
+    
+    Atom::Type Atom::getType() const noexcept
+    {
+        return m_type;
+    }
+    
+    bool Atom::isNull() const noexcept
+    {
+        return (m_type == Type::Null);
+    }
+    
+    bool Atom::isInt() const noexcept
+    {
+        return m_type == Type::Int;
+    }
+    
+    bool Atom::isFloat() const noexcept
+    {
+        return m_type == Type::Float;
+    }
+    
+    bool Atom::isNumber() const noexcept
+    {
+        return (isInt() || isFloat());
+    }
+    
+    bool Atom::isString() const noexcept
+    {
+        return m_type == Type::String;
+    }
+    
+    bool Atom::isBang() const
+    {
+        static const auto bang_str = "bang";
+        return isString() && getString() == bang_str;
+    }
+    
+    bool Atom::isComma() const noexcept
+    {
+        return m_type == Type::Comma;
+    }
+    
+    bool Atom::isDollar() const noexcept
+    {
+        return m_type == Type::Dollar;
+    }
+    
+    // ================================================================================ //
+    //                                   Value Getters                                  //
+    // ================================================================================ //
+    
+    Atom::int_t Atom::getInt() const noexcept
+    {
+        if(isInt())
+        {
+            return m_value.int_v;
+        }
+        else if(isFloat())
+        {
+            return static_cast<int_t>(m_value.float_v);
+        }
+        
+        return int_t(0);
+    }
+    
+    Atom::float_t Atom::getFloat() const noexcept
+    {
+        if(isFloat())
+        {
+            return m_value.float_v;
+        }
+        else if(isInt())
+        {
+            return static_cast<float_t>(m_value.int_v);
+        }
+        
+        return float_t(0.0);
+    }
+    
+    Atom::string_t const& Atom::getString() const
+    {
+        if(isString())
+        {
+            return *m_value.string_v;
+        }
+        
+        static const std::string empty_string;
+        return empty_string;
+    }
+    
+    //! @brief Retrieves the Dollar index value if the Atom is a dollar type.
+    //! @return The Dollar index if the Atom is a dollar, 0 otherwise.
+    //! @see getType(), isDollar(), isDollarTyped()
+    Atom::int_t Atom::getDollarIndex() const
+    {
+        return isDollar() ? m_value.int_v : 0;
+    }
+    
+    // ================================================================================ //
+    //                                      VALUE                                       //
+    // ================================================================================ //
+    
+    //! @internal Exception-safe object creation helper
+    Atom::string_t* Atom::create_string_pointer(string_t const& v)
+    {
+        std::allocator<string_t> alloc;
+        auto deleter = [&alloc](string_t * object) { alloc.deallocate(object, 1); };
+        std::unique_ptr<string_t, decltype(deleter)> object(alloc.allocate(1), deleter);
+        alloc.construct(object.get(), v);
+        return object.release();
+    }
+    
+    Atom::string_t* Atom::create_string_pointer(string_t&& v)
+    {
+        std::allocator<string_t> alloc;
+        auto deleter = [&alloc](string_t * object) { alloc.deallocate(object, 1); };
+        std::unique_ptr<string_t, decltype(deleter)> object(alloc.allocate(1), deleter);
+        alloc.construct(object.get(), std::move(v));
+        return object.release();
+    }
+    
+    // ================================================================================ //
+    //                                    ATOM HELPER                                   //
+    // ================================================================================ //
+
+    std::vector<Atom> AtomHelper::parse(std::string const& text, int flags)
+    {
+        std::vector<Atom> atoms;
+        const auto text_end = text.cend();
+        auto text_it = text.begin();
+        
+        enum class NumberState
+        {
+            NaN = -1,
+            MaybeNumber = 0,
+            GotMinus,
+            GotDigit,
+            GotDotWithoutDigit,
+            GotDotAfterDigit,
+            GotDigitAfterDot,
+            GotExpon,
+            GotPlusMinusAfterExpon,
+            GotDigitAfterExpon,
+        };
+        
+        enum class DollarState
+        {
+            NotDollar = -1,
+            MaybeDollar = 0,
+            GotDollar,
+            DollarValid, // $1 => $9
+        };
+        
+        for(;;)
+        {
+            // skip witespaces
+            while((text_it != text_end) && (*text_it == ' ' || (*text_it <= 13 && *text_it >= 9)))
+                text_it++;
+            
+            if(text_it == text_end)
+                break; // end of parsing
+            
+            std::ostringstream text_buffer;
+            
+            NumberState numstate = NumberState::MaybeNumber;
+            DollarState dollar_state = ((flags & ParsingFlags::Dollar)
+                                        ? DollarState::MaybeDollar
+                                        : DollarState::NotDollar);
+            
+            bool is_quoted   = false;
+            bool is_comma    = false;
+            int dollar_index = 0;
+            
+            bool lastslash = false;
+            bool slash = false;
+            
+            while(text_it != text_end)
+            {
+                bool buffer_is_empty = (((long)text_buffer.tellp()) == 0);
+                char c = *text_it;
+                lastslash = slash;
+                slash = (c == '\\');
+                
+                // skip witespaces characters
+                if(c == ' ' || (c <= 13 && c >= 9))
+                {
+                    // preserve whitespaces in quoted tags
+                    if(!is_quoted)
+                    {
+                        break;
+                    }
+                }
+                else if(c == '\"' && !lastslash)
+                {
+                    // closing quote
+                    if(is_quoted)
+                    {
+                        text_it++;
+                        break;
+                    }
+                    
+                    // opening quote
+                    if(buffer_is_empty)
+                    {
+                        text_it++;
+                        is_quoted = true;
+                        continue;
+                    }
+                }
+                else if(is_comma
+                        || ((flags & ParsingFlags::Comma) && (c == ',' && !is_quoted)))
+                {
+                    if(!buffer_is_empty)
+                    {
+                        break;
+                    }
+                    
+                    is_comma = true;
+                }
+                else if(!is_quoted && numstate >= NumberState::MaybeNumber)
+                {
+                    const bool digit = (c >= '0' && c <= '9'),
+                    dot = (c == '.'), minus = (c == '-'),
+                    plusminus = (minus || (c == '+')),
+                    expon = (c == 'e' || c == 'E');
+                    
+                    if (numstate == NumberState::MaybeNumber)
+                    {
+                        if (minus) numstate = NumberState::GotMinus;
+                        else if (digit) numstate = NumberState::GotDigit;
+                        else if (dot) numstate = NumberState::GotDotWithoutDigit;
+                        else numstate = NumberState::NaN;
+                    }
+                    else if (numstate == NumberState::GotMinus)
+                    {
+                        if (digit) numstate = NumberState::GotDigit;
+                        else if (dot) numstate = NumberState::GotDotWithoutDigit;
+                        else numstate = NumberState::NaN;
+                    }
+                    else if (numstate == NumberState::GotDigit)
+                    {
+                        if (dot) numstate = NumberState::GotDotAfterDigit;
+                        else if (expon) numstate = NumberState::GotDigit;
+                        else if (!digit) numstate = NumberState::NaN;
+                    }
+                    else if (numstate == NumberState::GotDotWithoutDigit)
+                    {
+                        if (digit) numstate = NumberState::GotDigitAfterDot;
+                        else numstate = NumberState::NaN;
+                    }
+                    else if (numstate == NumberState::GotDotAfterDigit)
+                    {
+                        if (digit) numstate = NumberState::GotDigitAfterDot;
+                        else if (expon) numstate = NumberState::GotExpon;
+                        else numstate = NumberState::NaN;
+                    }
+                    else if (numstate == NumberState::GotDigitAfterDot)
+                    {
+                        if (expon) numstate = NumberState::GotExpon;
+                        else if (!digit) numstate = NumberState::NaN;
+                    }
+                    else if (numstate == NumberState::GotExpon)
+                    {
+                        if (plusminus) numstate = NumberState::GotPlusMinusAfterExpon;
+                        else if (digit) numstate = NumberState::GotDigitAfterExpon;
+                        else numstate = NumberState::NaN;
+                    }
+                    else if (numstate == NumberState::GotPlusMinusAfterExpon)
+                    {
+                        if (digit) numstate = NumberState::GotDigitAfterExpon;
+                        else numstate = NumberState::NaN;
+                    }
+                    else if (numstate == NumberState::GotDigitAfterExpon)
+                    {
+                        if (!digit) numstate = NumberState::NaN;
+                    }
+                }
+                
+                if(dollar_state >= DollarState::MaybeDollar
+                   && numstate == NumberState::NaN && !is_quoted)
+                {
+                    if(dollar_state == DollarState::MaybeDollar)
+                    {
+                        dollar_state = ((buffer_is_empty && (c == '$') && !is_quoted && !lastslash)
+                                        ? DollarState::GotDollar
+                                        : DollarState::NotDollar);
+                    }
+                    else if (dollar_state == DollarState::GotDollar)
+                    {
+                        dollar_state = ((c > '0' && c <= '9')
+                                        ? DollarState::DollarValid
+                                        : DollarState::NotDollar);
+                        
+                        dollar_index = (dollar_state == DollarState::DollarValid ? (c - '0') : 0);
+                    }
+                    else if (dollar_state == DollarState::DollarValid)
+                    {
+                        if((c == ' ') || (flags & ParsingFlags::Comma && c == ','))
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            dollar_state = DollarState::NotDollar;
+                        }
+                    }
+                }
+                
+                // strip slashes
+                if(slash)
+                {
+                    if(!lastslash)
+                    {
+                        text_it++;
+                        continue;
+                    }
+                    else
+                    {
+                        slash = false;
+                    }
+                }
+                
+                text_buffer << c;
+                text_it++;
+            }
+            
+            const auto& word = text_buffer.str();
+            
+            if(!word.empty())
+            {
+                if(numstate == NumberState::GotDigit)
+                {
+                    atoms.emplace_back(std::stol(word));
+                }
+                else if(numstate == NumberState::GotDotAfterDigit
+                        || numstate == NumberState::GotDigitAfterDot
+                        || numstate == NumberState::GotDigitAfterExpon)
+                {
+                    atoms.emplace_back(std::stod(word));
+                }
+                else if(is_comma)
+                {
+                    atoms.emplace_back(Atom::Comma());
+                }
+                else if(dollar_state == DollarState::DollarValid)
+                {
+                    atoms.emplace_back(Atom::Dollar(dollar_index));
+                }
+                else
+                {
+                    atoms.emplace_back(word);
+                }
+            }
+        }
+        
+        return atoms;
+    }
+    
+    std::string AtomHelper::toString(Atom const& atom, const bool add_quotes)
+    {
+        switch(atom.getType())
+        {
+            case Atom::Type::Int:
+            {
+                return std::to_string(atom.getInt());
+            }
+            case Atom::Type::Float:
+            {
+                return trimDecimal(std::to_string(atom.getFloat()));
+            }
+            case Atom::Type::String:
+            {
+                const auto& str = atom.getString();
+                if(!str.empty())
+                {
+                    const bool need_quote = add_quotes && str.find_first_of(' ', 0) != std::string::npos;
+                    
+                    if(need_quote)
+                    {
+                        std::ostringstream output;
+                        output << "\"";
+                        
+                        // add slashes
+                        for(auto c : str)
+                        {
+                            if(c == '\\' || c == '"')
+                            {
+                                output << '\\';
+                            }
+                            
+                            output << c;
+                        }
+                        
+                        output << "\"";
+                        return output.str();
+                    }
+                    
+                    return str;
+                }
+            }
+            case Atom::Type::Comma:
+            {
+                return ",";
+            }
+            case Atom::Type::Dollar:
+            {
+                return "$" + std::to_string(atom.getDollarIndex());
+            }
+                
+            default : break;
+        }
+        
+        return {};
+    }
+    
+    std::string AtomHelper::toString(std::vector<Atom> const& atoms, const bool add_quotes)
+    {
+        static const auto delimiter = ' ';
+        std::ostringstream output;
+        if(!atoms.empty())
+        {
+            for(std::vector<Atom>::size_type i = 0; i < atoms.size();)
+            {
+                output << toString(atoms[i], add_quotes);
+                if(++i != atoms.size() && !atoms[i].isComma())
+                {
+                    output << delimiter;
+                }
+            }
+        }
+        
+        return output.str();
+    }
+    
+    std::string AtomHelper::trimDecimal(std::string const& text)
+    {
+        auto output = text;
+        auto pos = text.find('.');
+        
+        if(pos != std::string::npos)
+        {
+            auto size = text.size();
+            while(size > pos && text[size - 1] == '0')
+            {
+                output.pop_back();
+                size--;
+            }
+        }
+        
+        return output;
+    }
+    
+}}

--- a/Test/Tool/test_Atom.cpp
+++ b/Test/Tool/test_Atom.cpp
@@ -27,10 +27,6 @@
 
 using namespace kiwi::tool;
 
-//! @brief kiwi::Atom unit test
-//! @todo :
-//! - Add more tests to kiwi::Atom::parse method
-
 // ================================================================================ //
 //                                 ATOM CONSTRUCTORS                                //
 // ================================================================================ //
@@ -129,15 +125,15 @@ TEST_CASE("Atom Constructors", "[Atom]")
     }
     
     /*
-    SECTION("Unsigned Integral types are unsupported")
-    {
-        CHECK(Atom(1u).getType() == Atom::Type::Int);           // unsigned (int)
-        CHECK(Atom(1ul).getType() == Atom::Type::Int);          // unsigned long
-        CHECK(Atom(1lu).getType() == Atom::Type::Int);          // unsigned long
-        CHECK(Atom(1ull).getType() == Atom::Type::Int);         // unsigned long long
-        CHECK(Atom(1llu).getType() == Atom::Type::Int);         // unsigned long long
-    }
-    */
+     SECTION("Unsigned Integral types are unsupported")
+     {
+     CHECK(Atom(1u).getType() == Atom::Type::Int);           // unsigned (int)
+     CHECK(Atom(1ul).getType() == Atom::Type::Int);          // unsigned long
+     CHECK(Atom(1lu).getType() == Atom::Type::Int);          // unsigned long
+     CHECK(Atom(1ull).getType() == Atom::Type::Int);         // unsigned long long
+     CHECK(Atom(1llu).getType() == Atom::Type::Int);         // unsigned long long
+     }
+     */
     
     SECTION("Floating-Point types")
     {
@@ -207,18 +203,32 @@ TEST_CASE("Atom Constructors", "[Atom]")
     SECTION("Copy constructor")
     {
         Atom a_null;
-        Atom a_int(42);
-        Atom a_float(3.14);
-        Atom a_string("string");
-        
         Atom a_null_copy = a_null;
-        CHECK(a_null_copy.getType()  == Atom::Type::Null);
+        CHECK(a_null_copy.isNull());
+        
+        Atom a_int(42);
         Atom a_int_copy = a_int;
-        CHECK(a_int_copy.getType()   == Atom::Type::Int);
+        CHECK(a_int_copy.isInt());
+        CHECK(a_int_copy.getInt() == a_int.getInt());
+        
+        Atom a_float(3.14);
         Atom a_float_copy = a_float;
-        CHECK(a_float_copy.getType() == Atom::Type::Float);
+        CHECK(a_float_copy.isFloat());
+        CHECK(a_float_copy.getFloat() == a_float.getFloat());
+        
+        Atom a_string("string");
         Atom a_string_copy = a_string;
-        CHECK(a_string_copy.getType()== Atom::Type::String);
+        CHECK(a_string_copy.isString());
+        CHECK(a_string_copy.getString() == a_string.getString());
+        
+        Atom a_comma = Atom::Comma();
+        Atom a_comma_copy = a_comma;
+        CHECK(a_comma_copy.getType()== Atom::Type::Comma);
+        
+        Atom a_dollar = Atom::Dollar(1);
+        Atom a_dollar_copy = a_dollar;
+        CHECK(a_dollar_copy.isDollar());
+        CHECK(a_dollar_copy.getDollarIndex() == a_dollar.getDollarIndex());
     }
     
     SECTION("Copy assigment operator")
@@ -281,6 +291,14 @@ TEST_CASE("Atom Constructors", "[Atom]")
             CHECK(moved.isString()          == true);
             CHECK(moved.getString() == "string");
         }
+        
+        SECTION("std::string move ctor")
+        {
+            std::string str_to_move("string");
+            Atom moved(std::move(str_to_move));
+            CHECK(moved.isString()          == true);
+            CHECK(moved.getString() == "string");
+        }
     }
 }
 
@@ -333,6 +351,9 @@ TEST_CASE("Check Types", "[Atom]")
         CHECK(atom.isInt()          == false);
         CHECK(atom.isFloat()        == false);
         CHECK(atom.isString()       == false);
+        CHECK(atom.isBang()         == false);
+        CHECK(atom.isComma()        == false);
+        CHECK(atom.isDollar()       == false);
     }
     
     SECTION("Check Types (Int)")
@@ -344,6 +365,9 @@ TEST_CASE("Check Types", "[Atom]")
         CHECK(atom.isInt()          == true);
         CHECK(atom.isFloat()        == false);
         CHECK(atom.isString()       == false);
+        CHECK(atom.isBang()         == false);
+        CHECK(atom.isComma()        == false);
+        CHECK(atom.isDollar()       == false);
     }
     
     SECTION("Check Types (Float)")
@@ -355,6 +379,9 @@ TEST_CASE("Check Types", "[Atom]")
         CHECK(atom.isInt()          == false);
         CHECK(atom.isFloat()        == true);
         CHECK(atom.isString()       == false);
+        CHECK(atom.isBang()         == false);
+        CHECK(atom.isComma()        == false);
+        CHECK(atom.isDollar()       == false);
     }
     
     SECTION("Check Types (String)")
@@ -366,6 +393,51 @@ TEST_CASE("Check Types", "[Atom]")
         CHECK(atom.isInt()          == false);
         CHECK(atom.isFloat()        == false);
         CHECK(atom.isString()       == true);
+        CHECK(atom.isBang()         == false);
+        CHECK(atom.isComma()        == false);
+        CHECK(atom.isDollar()       == false);
+    }
+    
+    SECTION("Check Types (String) - bang")
+    {
+        Atom atom("bang");
+        CHECK(atom.getType()        == Atom::Type::String);
+        CHECK(atom.isNull()         == false);
+        CHECK(atom.isNumber()       == false);
+        CHECK(atom.isInt()          == false);
+        CHECK(atom.isFloat()        == false);
+        CHECK(atom.isString()       == true);
+        CHECK(atom.isBang()         == true);
+        CHECK(atom.isComma()        == false);
+        CHECK(atom.isDollar()       == false);
+    }
+    
+    SECTION("Check Types (Comma)")
+    {
+        Atom atom = Atom::Comma();
+        CHECK(atom.getType()        == Atom::Type::Comma);
+        CHECK(atom.isNull()         == false);
+        CHECK(atom.isNumber()       == false);
+        CHECK(atom.isInt()          == false);
+        CHECK(atom.isFloat()        == false);
+        CHECK(atom.isString()       == false);
+        CHECK(atom.isBang()         == false);
+        CHECK(atom.isComma()        == true);
+        CHECK(atom.isDollar()       == false);
+    }
+    
+    SECTION("Check Types (Dollar)")
+    {
+        Atom atom = Atom::Dollar(1);
+        CHECK(atom.getType()        == Atom::Type::Dollar);
+        CHECK(atom.isNull()         == false);
+        CHECK(atom.isNumber()       == false);
+        CHECK(atom.isInt()          == false);
+        CHECK(atom.isFloat()        == false);
+        CHECK(atom.isString()       == false);
+        CHECK(atom.isBang()         == false);
+        CHECK(atom.isComma()        == false);
+        CHECK(atom.isDollar()       == true);
     }
 }
 
@@ -409,4 +481,322 @@ TEST_CASE("Value getters", "[Atom]")
     }
 }
 
+// -------
+// Parser
+// -------
 
+TEST_CASE("Atom Parse", "[Atom]")
+{
+    SECTION("basic atom parsing")
+    {
+        const auto atoms = AtomHelper::parse("foo \"bar 42\" 1 -2 3.14 -3.14");
+        REQUIRE(atoms.size() == 6);
+        
+        CHECK(atoms[0].getString() == "foo");
+        CHECK(atoms[1].getString() == "bar 42");
+        
+        CHECK((atoms[2].isInt() && atoms[3].isInt()));
+        
+        CHECK(atoms[4].isFloat());
+        CHECK(atoms[4].getFloat() == 3.14);
+        
+        CHECK(atoms[5].isFloat());
+        CHECK(atoms[5].getFloat() == -3.14);
+    }
+    
+    SECTION("parse integer beginning with multiple zeros")
+    {
+        const auto atoms = AtomHelper::parse("000101");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isInt());
+        CHECK(atoms[0].getInt() == 101);
+    }
+    
+    SECTION("parse float beginning with multiple zeros")
+    {
+        const auto atoms = AtomHelper::parse("000.101");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isFloat());
+        CHECK(atoms[0].getFloat() == 0.101);
+    }
+    
+    SECTION("simple dot is a string")
+    {
+        const auto atoms = AtomHelper::parse(".");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isString());
+    }
+    
+    SECTION("dot following by digits is a Float")
+    {
+        const auto atoms = AtomHelper::parse(".001");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isFloat());
+    }
+    
+    SECTION("float values are trimmed")
+    {
+        const auto atoms = AtomHelper::parse(".001000");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isFloat());
+        CHECK(AtomHelper::toString(atoms[0]) == "0.001");
+    }
+    
+    SECTION("negative sign following by a dot and digits is a Float")
+    {
+        const auto atoms = AtomHelper::parse("-.001");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isFloat());
+        CHECK(atoms[0].getFloat() == -.001);
+    }
+    
+    SECTION("exponent is a Float")
+    {
+        const auto atoms = AtomHelper::parse("6.02e23");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isFloat());
+        CHECK(atoms[0].getFloat() == 6.02e23);
+    }
+    
+    SECTION("digits with more than one dot is a String")
+    {
+        const auto atoms = AtomHelper::parse("0.001.");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isString());
+    }
+    
+    SECTION("skip whitespaces")
+    {
+        const auto atoms = AtomHelper::parse("   toto   44");
+        CHECK(atoms.size() == 2);
+        CHECK(atoms[0].isString());
+        CHECK(atoms[0].getString() == "toto");
+        CHECK(atoms[1].isInt());
+        CHECK(atoms[1].getInt() == 44);
+    }
+    
+    SECTION("skip special whitespace characters")
+    {
+        const auto text = "\f\n\r\t\v  \f  \n  \r  \t  \v ";
+        const auto atoms = AtomHelper::parse(text);
+        REQUIRE(atoms.size() == 0);
+    }
+    
+    SECTION("preserve special whitespace characters in double-quoted text sequence")
+    {
+        const auto text = "\"\f\n\r\t\v  \f  \n  \r  \t  \v \"";
+        const auto atoms = AtomHelper::parse(text);
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isString());
+        CHECK(AtomHelper::toString(atoms) == text);
+        CHECK(AtomHelper::toString(atoms[0]) == text);
+        CHECK(atoms[0].getString() == "\f\n\r\t\v  \f  \n  \r  \t  \v ");
+    }
+    
+    SECTION("strip slashes")
+    {
+        const auto text = R"(\0\a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z)";
+        const auto text_result = "0abcdefghijklmnopqrstuvwxyz";
+        const auto atoms = AtomHelper::parse(text);
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isString());
+        CHECK(AtomHelper::toString(atoms) == text_result);
+        CHECK(AtomHelper::toString(atoms[0]) == text_result);
+        CHECK(atoms[0].getString() == text_result);
+    }
+    
+    SECTION("strip slashes double slash")
+    {
+        const auto text = R"(\\a\\b\\c\\d)";
+        const auto normal_text = "\\\\a\\\\b\\\\c\\\\d";
+        REQUIRE(text == normal_text);
+        
+        const auto atoms = AtomHelper::parse(text);
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isString());
+        
+        /*
+         CHECK(AtomHelper::toString(atoms) == text_result);
+         CHECK(AtomHelper::toString(atoms[0]) == text_result);
+         CHECK(atoms[0].getString() == text_result);
+         */
+    }
+    
+    SECTION("foo \"bar 42\" 1 -2 3.14")
+    {
+        const auto atoms = AtomHelper::parse("foo \"bar 42\" 1 -2 3.14");
+        REQUIRE(atoms.size() == 5);
+        CHECK(atoms[0].getString() == "foo");
+        CHECK(atoms[1].getString() == "bar 42");
+        CHECK((atoms[2].isInt() && atoms[3].isInt()));
+        CHECK(atoms[4].isFloat());
+    }
+    
+    SECTION("test escaping")
+    {
+        const auto original_text = R"(foo "bar 42" 1 -2 3.14)";
+        const auto atoms = AtomHelper::parse(original_text);
+        const auto text = AtomHelper::toString(atoms);
+        CHECK(text == original_text);
+    }
+}
+
+TEST_CASE("Atom Parse Quoted", "[Atom]")
+{
+    SECTION("basic")
+    {
+        const auto atoms = AtomHelper::parse("\"0 10\"");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isString());
+        CHECK(atoms[0].getString() == "0 10");
+    }
+    
+    SECTION("with comma")
+    {
+        const auto atoms = AtomHelper::parse(R"("0, 10")");
+        REQUIRE(atoms.size() == 1);
+        CHECK(atoms[0].isString());
+        CHECK(atoms[0].getString() == "0, 10");
+    }
+    
+    SECTION("with escaped quote")
+    {
+        const auto typed_text = R"("name: \"toto\"")";
+        const auto formated_text = R"("name: \"toto\"")";
+        const auto display_text = R"(name: "toto")";
+        
+        const auto atoms = AtomHelper::parse(typed_text);
+        REQUIRE(atoms.size() == 1);
+        REQUIRE(atoms[0].isString());
+        
+        CHECK(atoms[0].getString() == display_text);
+        CHECK(AtomHelper::toString(atoms[0]) == formated_text);
+        CHECK(AtomHelper::toString(atoms[0], false) == display_text);
+    }
+}
+
+TEST_CASE("Atom Parse Comma", "[Atom]")
+{
+    SECTION("parse \"0, 10\" without comma option")
+    {
+        const auto atoms = AtomHelper::parse("0, 10");
+        REQUIRE(atoms.size() == 2);
+        CHECK(atoms[0].isString());
+        CHECK(atoms[0].getString() == "0,");
+        CHECK(atoms[1].isInt());
+    }
+    
+    SECTION("parse \"0, 10\" without flag then toString")
+    {
+        const auto typed_text = R"(0, 10)";
+        const auto text_to_display = R"(0, 10)";
+        const auto atoms = AtomHelper::parse(typed_text);
+        REQUIRE(atoms.size() == 2);
+        CHECK(atoms[0].getString() == "0,");
+        CHECK(AtomHelper::toString(atoms[0]) == "0,");
+        const auto formated_text = AtomHelper::toString(atoms);
+        CHECK(text_to_display == formated_text);
+    }
+    
+    SECTION("parse with comma flag")
+    {
+        const auto atoms = AtomHelper::parse("0, 10", AtomHelper::ParsingFlags::Comma);
+        REQUIRE(atoms.size() == 3);
+        CHECK(atoms[0].isInt());
+        CHECK(atoms[1].isComma());
+        CHECK(atoms[2].isInt());
+    }
+    
+    SECTION("parse \"0, 10\" with comma flag then toString")
+    {
+        const auto original_text = "0, 10";
+        const auto atoms = AtomHelper::parse(original_text, AtomHelper::ParsingFlags::Comma);
+        REQUIRE(atoms.size() == 3);
+        const auto text = AtomHelper::toString(atoms);
+        CHECK(text == original_text);
+    }
+    
+    SECTION("parse comma without space after it")
+    {
+        const auto original_text = "0,10";
+        const auto atoms = AtomHelper::parse(original_text, AtomHelper::ParsingFlags::Comma);
+        REQUIRE(atoms.size() == 3);
+        CHECK(atoms[0].isInt());
+        CHECK(atoms[1].isComma());
+        CHECK(atoms[2].isInt());
+        const auto text = AtomHelper::toString(atoms);
+        CHECK(text == "0, 10");
+    }
+    
+    SECTION("parse several commas")
+    {
+        const auto original_text = ",,,";
+        const auto atoms = AtomHelper::parse(original_text, AtomHelper::ParsingFlags::Comma);
+        REQUIRE(atoms.size() == 3);
+        CHECK(atoms[0].isComma());
+        CHECK(atoms[1].isComma());
+        CHECK(atoms[2].isComma());
+        const auto text = AtomHelper::toString(atoms);
+        CHECK(text == ",,,");
+    }
+}
+
+TEST_CASE("Atom Parse Dollar", "[Atom]")
+{
+    const int flags = AtomHelper::ParsingFlags::Dollar;
+    
+    SECTION("parse without dollar flags")
+    {
+        const auto atoms = AtomHelper::parse("$1 $2 $3 $4 $5 $6 $7 $8 $9");
+        REQUIRE(atoms.size() == 9);
+        for (auto const& atom : atoms)
+        {
+            CHECK(atom.isString());
+        }
+    }
+    
+    SECTION("invalid dollar atoms")
+    {
+        const auto atoms = AtomHelper::parse("$0 a$1 $10 $-1 $ $$", AtomHelper::ParsingFlags::Dollar);
+        REQUIRE(atoms.size() == 6);
+        for (auto const& atom : atoms)
+        {
+            CHECK(atom.isString());
+            CHECK(atom.getDollarIndex() == 0);
+        }
+    }
+    
+    SECTION("valid dollar atoms")
+    {
+        const auto atoms = AtomHelper::parse("$1 $2 $3 $4 $5 $6 $7 $8 $9", AtomHelper::ParsingFlags::Dollar);
+        REQUIRE(atoms.size() == 9);
+        for (auto const& atom : atoms)
+        {
+            REQUIRE(atom.isDollar());
+            
+            static auto count = 0;
+            CHECK(++count == atom.getDollarIndex());
+        }
+    }
+    
+    SECTION("dollar followed by comma")
+    {
+        const auto atoms = AtomHelper::parse("$1, $2",
+                                             AtomHelper::ParsingFlags::Dollar
+                                             | AtomHelper::ParsingFlags::Comma);
+        REQUIRE(atoms.size() == 3);
+        CHECK(atoms[0].isDollar());
+        CHECK(atoms[1].isComma());
+        CHECK(atoms[2].isDollar());
+    }
+    
+    SECTION("dollar followed by comma without Comma flag")
+    {
+        const auto atoms = AtomHelper::parse("$1, $2",
+                                             AtomHelper::ParsingFlags::Dollar);
+        REQUIRE(atoms.size() == 2);
+        CHECK(atoms[0].isString());
+        CHECK(atoms[0].getString() == "$1,");
+        CHECK(atoms[1].isDollar());
+    }
+}


### PR DESCRIPTION
- Improved the Atom Parser method (strip and add slashes)
- Added the Dollar and Comma Atom pseudo-types
- Support the Dollar and Comma syntax in the [message] object.
- Improve Atom test coverage