### PR TITLE
Dev/bug-fix v1.0.1

### DIFF
--- a/Client/Source/KiwiApp_General/KiwiApp_CommandIDs.h
+++ b/Client/Source/KiwiApp_General/KiwiApp_CommandIDs.h
@@ -68,7 +68,6 @@ namespace kiwi
         
         newBox                      = 0xf30300,        ///< Add a new "box" to the patcher.
         newMessage                  = 0xf30301,        ///< Add a new "message" object box to the patcher.
-        newFlonum                   = 0xf30302,        ///< Add a new "flonum" object box to the patcher.
         newNumber                   = 0xf30303,        ///< Add a new "number" object box to the patcher.
         newComment                  = 0xf30304,        ///< Add a new "comment" object box to the patcher.
         newBang                     = 0xf30305,        ///< Add a new "button" object box to the patcher.

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_BangView.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_BangView.cpp
@@ -40,14 +40,15 @@ namespace kiwi {
         return std::make_unique<BangView>(model);
     }
     
-    BangView::BangView(model::Object & model):
-    ObjectView(model),
-    m_signal(model.getSignal<>(model::Bang::Signal::TriggerBang)),
-    m_connection(m_signal.connect(std::bind(&BangView::signalTriggered, this))),
-    m_active(false),
-    m_mouse_down(false)
-    {
-    }
+    BangView::BangView(model::Object & model)
+    : ObjectView(model)
+    , m_trigger_signal(model.getSignal<>(model::Bang::Signal::TriggerBang))
+    , m_flash_signal(model.getSignal<>(model::Bang::Signal::FlashBang))
+    , m_trigger_connection(m_trigger_signal.connect(std::bind(&BangView::signalTriggered, this)))
+    , m_flash_connection(m_flash_signal.connect(std::bind(&BangView::signalTriggered, this)))
+    , m_active(false)
+    , m_mouse_down(false)
+    {}
     
     BangView::~BangView()
     {
@@ -81,7 +82,7 @@ namespace kiwi {
         m_mouse_down = true;
         repaint();
         
-        m_signal();
+        m_trigger_signal();
     }
     
     void BangView::mouseUp(juce::MouseEvent const& e)

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_BangView.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_BangView.h
@@ -62,8 +62,10 @@ namespace kiwi {
     private: // members
         
         //! @todo Put border into ObjectView.
-        flip::Signal<>&                                 m_signal;
-        flip::SignalConnection                          m_connection;
+        flip::Signal<>&                                 m_trigger_signal;
+        flip::Signal<>&                                 m_flash_signal;
+        flip::SignalConnection                          m_trigger_connection;
+        flip::SignalConnection                          m_flash_connection;
         bool                                            m_active;
         bool                                            m_mouse_down;
         

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberTildeView.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberTildeView.cpp
@@ -38,12 +38,20 @@ namespace kiwi {
         return std::make_unique<NumberTildeView>(object_model);
     }
     
-    NumberTildeView::NumberTildeView(model::Object & object_model) :
-    NumberViewBase(object_model)
+    NumberTildeView::NumberTildeView(model::Object & object_model)
+    : NumberViewBase(object_model)
     {
         setEditable(false);
-        setIconColour(findColour(ObjectView::ColourIds::Active));
         setInterceptsMouseClicks(false, false);
+    }
+    
+    void NumberTildeView::drawIcon (juce::Graphics& g) const
+    {
+        g.setColour (findColour (ObjectView::ColourIds::Active));
+        
+        g.setFont(22.f);
+        g.drawFittedText("~", getLocalBounds().withWidth(getHeight()).withX(2),
+                         juce::Justification::centredLeft, 1);
     }
     
     void NumberTildeView::parameterChanged(std::string const& name, tool::Parameter const& param)

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberTildeView.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberTildeView.h
@@ -48,6 +48,8 @@ namespace kiwi {
         
     private: // methods
         
+        void drawIcon (juce::Graphics& g) const override;
+        
         //! @brief Called when the displayed number has just changed.
         void displayNumberChanged(double new_number) override final;
         

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberView.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberView.cpp
@@ -40,18 +40,34 @@ namespace kiwi {
         return std::make_unique<NumberView>(object_model);
     }
     
-    NumberView::NumberView(model::Object & object_model) :
-    NumberViewBase(object_model),
-    m_output_message(object_model.getSignal<>(model::Message::Signal::outputMessage)),
-    m_sensitivity(1),
-    m_mouse_info()
+    NumberView::NumberView(model::Object & object_model)
+    : NumberViewBase(object_model)
+    , m_output_message(object_model.getSignal<>(model::Message::Signal::outputMessage))
+    , m_sensitivity(1)
+    , m_mouse_info()
     {
-        setIconColour(findColour(ObjectView::ColourIds::Outline));
         setInterceptsMouseClicks(true, true);
     }
     
     NumberView::~NumberView()
     {
+    }
+    
+    void NumberView::drawIcon (juce::Graphics& g) const
+    {
+        g.setColour(findColour(ObjectView::ColourIds::Outline));
+        
+        const juce::Rectangle<int> icon_bounds = getLocalBounds()
+        .withWidth(m_indent - 4).withHeight(getHeight() - 8).translated(2, 4);
+        
+        juce::Path corner;
+        
+        corner.addTriangle(icon_bounds.getTopLeft().toFloat(),
+                           icon_bounds.getTopRight().toFloat()
+                           + juce::Point<float>(0, (icon_bounds.getHeight() / 2.)),
+                           icon_bounds.getBottomLeft().toFloat());
+        
+        g.fillPath(corner);
     }
     
     void NumberView::mouseDoubleClick(juce::MouseEvent const& e)
@@ -66,7 +82,7 @@ namespace kiwi {
         m_mouse_info.m_mouse_down_value = getDisplayNumber();
         m_mouse_info.m_mouse_down_y = e.y;
         
-        if (e.mods.isAltDown())
+        if (e.mods.isShiftDown())
         {
             m_mouse_info.m_is_alt_down = true;
             m_mouse_info.m_alt_down_value = getDisplayNumber();
@@ -78,15 +94,15 @@ namespace kiwi {
     {
         if (e.getDistanceFromDragStartY() != 0)
         {
-            double new_value = 0;
+            double new_value = m_value;
             
-            if (!m_mouse_info.m_is_alt_down && e.mods.isAltDown())
+            if (!m_mouse_info.m_is_alt_down && e.mods.isShiftDown())
             {
                 m_mouse_info.m_is_alt_down = true;
                 m_mouse_info.m_alt_down_value = getDisplayNumber();
                 m_mouse_info.m_alt_down_y = e.y;
             }
-            else if(m_mouse_info.m_is_alt_down && !e.mods.isAltDown())
+            else if(m_mouse_info.m_is_alt_down && !e.mods.isShiftDown())
             {
                 m_mouse_info.m_mouse_down_value = getDisplayNumber();
                 m_mouse_info.m_mouse_down_y = e.y;
@@ -95,7 +111,7 @@ namespace kiwi {
                 m_mouse_info.m_alt_down_y = 0;
             }
             
-            if (e.mods.isAltDown())
+            if (e.mods.isShiftDown())
             {
                 new_value = m_mouse_info.m_alt_down_value - (m_sensitivity * (e.y - m_mouse_info.m_alt_down_y)) / 100.;
             }
@@ -104,9 +120,12 @@ namespace kiwi {
                 new_value = m_mouse_info.m_mouse_down_value - m_sensitivity * (e.y - m_mouse_info.m_mouse_down_y);
             }
             
-            setParameter("value", tool::Parameter(tool::Parameter::Type::Float, {new_value}));
-            m_output_message();
-            repaint();
+            if(new_value != m_value)
+            {
+                setParameter("value", tool::Parameter(tool::Parameter::Type::Float, {new_value}));
+                m_output_message();
+                repaint();
+            }
         }
     }
     

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberView.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberView.h
@@ -34,17 +34,6 @@ namespace kiwi {
     //! @brief The view of any textual kiwi object.
     class NumberView : public NumberViewBase
     {
-    private: // members
-        
-        struct MouseInfo
-        {
-            double  m_mouse_down_value  = 0;
-            int     m_mouse_down_y      = 0;
-            bool    m_is_alt_down       = false;
-            double  m_alt_down_value    = 0;
-            int     m_alt_down_y        = 0;
-        };
-        
     public: // methods
         
         // @brief The declaration method.
@@ -83,9 +72,10 @@ namespace kiwi {
         
     private: // members
         
-        flip::Signal<> &    m_output_message;
-        int                 m_sensitivity;
-        MouseInfo           m_mouse_info;
+        flip::Signal<>& m_output_message;
+        int m_decimal_drag = 0;
+        juce::Point<float> m_last_drag_pos {};
+        double m_drag_value = 0;
         
     private: // deleted methods
         

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberView.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberView.h
@@ -61,6 +61,8 @@ namespace kiwi {
         
     private: // methods
         
+        void drawIcon (juce::Graphics& g) const override;
+        
         //! @brief Stores the initial value before draging.
         void mouseDown(juce::MouseEvent const& e) override final;
         

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberViewBase.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberViewBase.cpp
@@ -89,7 +89,7 @@ namespace kiwi {
         m_value = number;
         
         juce::String display_value(std::to_string(m_value));
-        
+
         display_value = display_value.trimCharactersAtEnd("0");
         
         getLabel().setText(display_value, juce::NotificationType::dontSendNotification);
@@ -97,7 +97,7 @@ namespace kiwi {
     
     void NumberViewBase::textChanged()
     {
-        m_value = getLabel().getText().getFloatValue();
+        m_value = getLabel().getText().getDoubleValue();
         
         displayNumberChanged(m_value);
     }

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberViewBase.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberViewBase.cpp
@@ -30,11 +30,10 @@ namespace kiwi {
     //                                   NUMBER VIEW BASE                               //
     // ================================================================================ //
     
-    NumberViewBase::NumberViewBase(model::Object & object_model) :
-    EditableObjectView(object_model),
-    m_value(0),
-    m_indent(9),
-    m_icon_colour(findColour (ObjectView::ColourIds::Outline))
+    NumberViewBase::NumberViewBase(model::Object & object_model)
+    : EditableObjectView(object_model)
+    , m_value(0)
+    , m_indent(9)
     {
         juce::Label & label = getLabel();
         
@@ -65,18 +64,12 @@ namespace kiwi {
         g.setColour (findColour (ObjectView::ColourIds::Outline));
         
         drawOutline(g);
-        
-        juce::Path corner;
-        
-        g.setColour(m_icon_colour);
-        
-        juce::Rectangle<int> triangle_bounds = getLocalBounds().withWidth(m_indent - 4).withHeight(getHeight() - 8).translated(2, 4);
-        
-        corner.addTriangle(triangle_bounds.getTopLeft().toFloat(),
-                           triangle_bounds.getTopRight().toFloat() + juce::Point<float>(0, (triangle_bounds.getHeight() / 2.)),
-                           triangle_bounds.getBottomLeft().toFloat());
-        
-        g.fillPath(corner);
+        drawIcon(g);
+    }
+    
+    void NumberViewBase::drawIcon (juce::Graphics& g) const
+    {
+        // nothing by default
     }
     
     void NumberViewBase::resized()
@@ -84,11 +77,6 @@ namespace kiwi {
         juce::Rectangle<int> label_bounds = getLocalBounds();
         label_bounds.removeFromLeft(m_indent);
         getLabel().setBounds(label_bounds);
-    }
-    
-    void NumberViewBase::setIconColour(juce::Colour colour)
-    {
-        m_icon_colour = colour;
     }
     
     double NumberViewBase::getDisplayNumber() const

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberViewBase.h
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_NumberViewBase.h
@@ -50,9 +50,7 @@ namespace kiwi {
         //! @brief Returns the displayed text as a number.
         double getDisplayNumber() const;
         
-        //! @brief Sets the triangle icon colour.
-        //! @details By default colour is outline colour.
-        void setIconColour(juce::Colour colour);
+        virtual void drawIcon (juce::Graphics& g) const;
         
     private: // methods
         
@@ -78,11 +76,10 @@ namespace kiwi {
         //! @details Overrides EditableOjectView::createTextEditor.
         juce::TextEditor* createdTextEditor() override final;
         
-    private: // members
+    protected: // members
         
         double              m_value;
         int                 m_indent;
-        juce::Colour        m_icon_colour;
         
     private: // deleted methods
         

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_ObjectView.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_Objects/KiwiApp_ObjectView.cpp
@@ -55,11 +55,11 @@ namespace kiwi
     
     void ObjectView::setAttribute(std::string const& name, tool::Parameter const& parameter)
     {
-        model::Object & object_model = getModel();
-        
+        model::Object& object_model = getModel();
         object_model.setAttribute(name, parameter);
         
-        model::DocumentManager::commit(object_model);
+        const auto commit_msg = object_model.getName() + " \"" + name + "\" changed";
+        model::DocumentManager::commit(object_model, commit_msg);
     }
     
     void ObjectView::setParameter(std::string const& name, tool::Parameter const& parameter)

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherView.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherView.cpp
@@ -1827,6 +1827,7 @@ namespace kiwi
         commands.add(CommandIDs::newSlider);
         commands.add(CommandIDs::newMessage);
         commands.add(CommandIDs::newComment);
+        commands.add(CommandIDs::newNumber);
         
         commands.add(CommandIDs::zoomIn);
         commands.add(CommandIDs::zoomOut);
@@ -1973,6 +1974,14 @@ namespace kiwi
                 result.setActive(!isLocked());
                 break;
             }
+            case CommandIDs::newNumber:
+            {
+                result.setInfo(TRANS("New Number Box"), TRANS("Add a new number"), CommandCategories::editing, 0);
+                result.addDefaultKeypress('f', juce::ModifierKeys::noModifiers);
+                result.addDefaultKeypress('i', juce::ModifierKeys::noModifiers);
+                result.setActive(!isLocked());
+                break;
+            }
             case CommandIDs::newComment:
             {
                 result.setInfo(TRANS("New Comment Box"),
@@ -2059,9 +2068,10 @@ namespace kiwi
             case juce::StandardApplicationCommandIDs::selectAll:{ selectAllObjects(); break; }
             
             case CommandIDs::newBox:                            { createObjectModel("", true); break; }
-            case CommandIDs::newBang:                           { createObjectModel("bang", true); break; }
-            case CommandIDs::newToggle:                         { createObjectModel("toggle", true); break; }
-            case CommandIDs::newSlider:                         { createObjectModel("slider", true); break; }
+            case CommandIDs::newBang:                           { createObjectModel("bang", false); break; }
+            case CommandIDs::newToggle:                         { createObjectModel("toggle", false); break; }
+            case CommandIDs::newNumber:                         { createObjectModel("number", false); break; }
+            case CommandIDs::newSlider:                         { createObjectModel("slider", false); break; }
             case CommandIDs::newComment:                        { createObjectModel("comment", true); break; }
             case CommandIDs::newMessage:                        { createObjectModel("message", true); break; }
                 

--- a/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherViewIoletHighlighter.cpp
+++ b/Client/Source/KiwiApp_Patcher/KiwiApp_PatcherViewIoletHighlighter.cpp
@@ -77,10 +77,7 @@ namespace kiwi
     
     void IoletHighlighter::highlight(ObjectFrame const& object, const size_t index, bool is_inlet)
     {
-        const auto& object_model = object.getModel();
-        
-        auto new_name = object_model.getName();
-        auto new_text = object_model.getIODescription(m_is_inlet, index);
+        auto const& object_model = object.getModel();
         
         //! Only hilight if either no pin is currently hilighted
         //! or hilighted pin is different.

--- a/Modules/KiwiEngine/KiwiEngine_Object.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Object.cpp
@@ -97,7 +97,7 @@ namespace kiwi
         
         void Object::setAttribute(std::string const& name, tool::Parameter && param)
         {
-            deferMain([this, name, param {std::move(param)}]() {
+            deferMain([this, name, param = std::move(param)]() {
                 
                 auto& object_model = getObjectModel();
                 object_model.setAttribute(name, param);                
@@ -108,7 +108,7 @@ namespace kiwi
         
         void Object::setParameter(std::string const& name, tool::Parameter && param)
         {
-            deferMain([this, name, param {std::move(param)}]() {
+            deferMain([this, name, param = std::move(param)]() {
                 getObjectModel().setParameter(name, param);
             });
         }

--- a/Modules/KiwiEngine/KiwiEngine_Object.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Object.cpp
@@ -81,14 +81,10 @@ namespace kiwi
             });
         }
         
-        model::Object & Object::getObjectModel()
+        model::Object& Object::getObjectModel()
         {
-            flip::Array<model::Object> & objects = m_patcher.getPatcherModel().getObjects();
-    
-            return *std::find_if(objects.begin(), objects.end(), [this](model::Object const & object_model)
-            {
-                return object_model.ref() == m_ref;
-            });
+            return m_patcher.getPatcherModel().document()
+            .object<model::Object>(m_ref);
         }
         
         void Object::parameterChanged(std::string const& param_name, tool::Parameter const& param)
@@ -99,20 +95,20 @@ namespace kiwi
         {
         }
         
-        void Object::setAttribute(std::string const& name, tool::Parameter const& param)
+        void Object::setAttribute(std::string const& name, tool::Parameter && param)
         {
-            deferMain([this, name, param]()
-            {
-                getObjectModel().setAttribute(name, param);
+            deferMain([this, name, param {std::move(param)}]() {
                 
-                model::DocumentManager::commit(getObjectModel());
+                auto& object_model = getObjectModel();
+                object_model.setAttribute(name, param);                
+                model::DocumentManager::commit(object_model);
+                
             });
         }
         
-        void Object::setParameter(std::string const& name, tool::Parameter const& param)
+        void Object::setParameter(std::string const& name, tool::Parameter && param)
         {
-            deferMain([this, name, param]
-            {
+            deferMain([this, name, param {std::move(param)}]() {
                 getObjectModel().setParameter(name, param);
             });
         }

--- a/Modules/KiwiEngine/KiwiEngine_Object.h
+++ b/Modules/KiwiEngine/KiwiEngine_Object.h
@@ -140,11 +140,11 @@ namespace kiwi
             
             //! @brief Changes one of the data model's attributes.
             //! @details For thread safety actual model's modification is called on the main thread.
-            void setAttribute(std::string const& name, tool::Parameter const& parameter);
+            void setAttribute(std::string const& name, tool::Parameter && parameter);
             
             //! @brief Changes one of the data model's parameter.
             //! @details For thread safety actual model's modification is called on the main thread.
-            void setParameter(std::string const& name, tool::Parameter const& parameter);
+            void setParameter(std::string const& name, tool::Parameter && parameter);
             
         private: // methods
             

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Bang.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Bang.cpp
@@ -40,10 +40,11 @@ namespace kiwi { namespace engine {
         return std::make_unique<Bang>(model, patcher);
     }
     
-    Bang::Bang(model::Object const& model, Patcher & patcher):
-    Object(model, patcher),
-    m_signal(model.getSignal<>(model::Bang::Signal::TriggerBang)),
-    m_connection(m_signal.connect(std::bind(&Bang::signalTriggered, this)))
+    Bang::Bang(model::Object const& model, Patcher & patcher)
+    : Object(model, patcher)
+    , m_trigger_signal(model.getSignal<>(model::Bang::Signal::TriggerBang))
+    , m_flash_signal(model.getSignal<>(model::Bang::Signal::FlashBang))
+    , m_connection(m_trigger_signal.connect(std::bind(&Bang::signalTriggered, this)))
     {
     }
     
@@ -61,9 +62,16 @@ namespace kiwi { namespace engine {
     
     void Bang::receive(size_t index, std::vector<tool::Atom> const& args)
     {
-        if (index == 0)
+        if (index == 0 && !args.empty())
         {
-            m_signal();
+            if(args[0].getString() == "set")
+            {
+                m_flash_signal();
+            }
+            else
+            {
+                m_trigger_signal();
+            }
         }
     }
     

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Bang.h
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Bang.h
@@ -47,7 +47,8 @@ namespace kiwi { namespace engine {
         
     private: // members
         
-        flip::Signal<> &        m_signal;
+        flip::Signal<>&         m_trigger_signal;
+        flip::Signal<>&         m_flash_signal;
         flip::SignalConnection  m_connection;
     };
 

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Hub.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Hub.cpp
@@ -62,11 +62,8 @@ namespace kiwi { namespace engine {
     {
         if (index == 0 && !args.empty())
         {
-            setAttribute("message",
-                         tool::Parameter(tool::Parameter::Type::String,
-                                         {tool::AtomHelper::toString(args)}));
+            setAttribute("message", { tool::Parameter::Type::String, {tool::AtomHelper::toString(args)}});
         }
     }
     
 }}
-

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Random.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Random.cpp
@@ -52,15 +52,29 @@ namespace kiwi { namespace engine {
     
     void Random::receive(size_t index, std::vector<tool::Atom> const& args)
     {
+        if(args.empty())
+            return; // abort
+        
         if (index == 0)
         {
             if (args[0].isBang())
             {
                 send(0, {getNextRandomValue()});
             }
+            else if (args[0].getString() == "seed")
+            {
+                if(args.size() > 1 && args[1].isNumber())
+                {
+                    setSeed(args[1].getInt());
+                }
+                else
+                {
+                    warning("random: seed message must be followed by an integer");
+                }
+            }
             else
             {
-                warning("random: inlet 1 only understands bang");
+                warning("random: inlet 1 only understands bang or seed message");
             }
         }
         else if (index == 1)
@@ -72,17 +86,6 @@ namespace kiwi { namespace engine {
             else
             {
                 warning("random: inlet 2 only understands numbers");
-            }
-        }
-        else if (index == 2)
-        {
-            if (args[0].isNumber())
-            {
-                setSeed(args[0].getInt());
-            }
-            else
-            {
-                warning("random: inlet 3 only understands numbers");
             }
         }
     }

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Random.cpp
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Random.cpp
@@ -60,7 +60,7 @@ namespace kiwi { namespace engine {
             }
             else
             {
-                warning("random: inlet 1 only understand bang");
+                warning("random: inlet 1 only understands bang");
             }
         }
         else if (index == 1)
@@ -71,7 +71,7 @@ namespace kiwi { namespace engine {
             }
             else
             {
-                warning("random: inlet 2 only understand numbers");
+                warning("random: inlet 2 only understands numbers");
             }
         }
         else if (index == 2)
@@ -82,14 +82,14 @@ namespace kiwi { namespace engine {
             }
             else
             {
-                warning("random: inlet 3 only understand numbers");
+                warning("random: inlet 3 only understands numbers");
             }
         }
     }
     
     void Random::setRange(int64_t range)
     {
-        m_random_distribution.param(rnd_distribution_t::param_type(0ll, std::max(0ll, range - 1)));
+        m_random_distribution.param(rnd_distribution_t::param_type(0, std::max<int64_t>(0, range - 1)));
     }
     
     void Random::setSeed(int64_t seed)

--- a/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Random.h
+++ b/Modules/KiwiEngine/KiwiEngine_Objects/KiwiEngine_Random.h
@@ -23,6 +23,7 @@
 
 #include <KiwiEngine/KiwiEngine_Object.h>
 
+#include <chrono>
 #include <random>
 
 namespace kiwi { namespace engine {
@@ -45,14 +46,19 @@ namespace kiwi { namespace engine {
         
     private: // methods
         
-        void setRange(int range);
+        void setRange(int64_t range);
+        void setSeed(int64_t new_seed);
         
-        void setSeed(int new_seed);
+        int64_t getNextRandomValue();
         
     private: // members
         
-        std::mt19937                        m_random_generator;
-        std::uniform_int_distribution<int>  m_random_distribution;
+        using clock_t = std::chrono::high_resolution_clock;
+        using rnd_distribution_t = std::uniform_int_distribution<int64_t>;
+        
+        clock_t::time_point m_start_time { clock_t::now() };
+        std::mt19937        m_random_generator {};
+        rnd_distribution_t  m_random_distribution {0ll, 0ll};
     };
     
 }}

--- a/Modules/KiwiModel/KiwiModel_Converters/KiwiModel_Converter.cpp
+++ b/Modules/KiwiModel/KiwiModel_Converters/KiwiModel_Converter.cpp
@@ -24,6 +24,8 @@
 #include <KiwiModel/KiwiModel_Def.h>
 #include <KiwiModel/KiwiModel_Converters/KiwiModel_Converter.h>
 
+#include <KiwiTool/KiwiTool_Atom.h>
+
 namespace kiwi { namespace model {
 
     // ================================================================================ //
@@ -32,7 +34,7 @@ namespace kiwi { namespace model {
     
     void Converter::convert_v1_v2(flip::BackEndIR & backend)
     {
-        flip::BackEndIR::Type & patcher  = backend.root;
+        flip::BackEndIR::Type& patcher = backend.root;
         
         // removing patcher name.
         patcher.members.remove_if([](std::pair<std::string, flip::BackEndIR::Type> const& member)
@@ -40,34 +42,142 @@ namespace kiwi { namespace model {
             return member.first == "patcher_name";
         });
         
-        backend.version = "v2";
+        backend.complete_conversion("v2");
+    }
+    
+    void Converter::convert_v3_v4(flip::BackEndIR & backend)
+    {
+        flip::BackEndIR::Type& patcher = backend.root;
+        
+        // random object conversion:
+        // - remove seed inlet (was third inlet in < v4)
+        // - remove range inlet (second) if range argument is defined
+        
+        walk(patcher, [](flip::BackEndIR::Type& type) {
+            
+            if (type.get_class () != "cicm.kiwi.object.random")
+                return; // abort
+            
+            auto const& text_value = type.member("text").second.value.blob;
+            const std::string text { text_value.begin(), text_value.end() };
+            const auto parsed_text = tool::AtomHelper::parse(text);
+            
+            auto& inlets = type.member("inlets").second.array;
+            
+            if(inlets.size() == 3)
+            {
+                inlets.erase(inlets.begin());
+                
+                const bool has_range_arg = (parsed_text.size() > 1
+                                            && parsed_text[1].isNumber());
+                if(has_range_arg)
+                {
+                    inlets.erase(inlets.begin());
+                }
+            }
+        });
+        
+        backend.complete_conversion("v4");
+    }
+    
+    void Converter::remove_invalid_links(flip::BackEndIR& backend)
+    {
+        flip::BackEndIR::Type& patcher  = backend.root;
+        
+        auto& objects = patcher.member("objects").second.array;
+        
+        // A link is considered invalid if sender or receiver object does not exist,
+        // or if it's bound to a pin that does not exist.
+        auto is_invalid_link = [&objects](flip::BackEndIR::Type& type) {
+            
+            auto const& sender_ref = type.member("sender_obj").second.value.ref;
+            auto const& receiver_ref = type.member("receiver_obj").second.value.ref;
+            auto const& sender_outlet = type.member("outlet_index").second.value.int_num;
+            auto const& receiver_inlet = type.member("inlet_index").second.value.int_num;
+            
+            bool sender_found = false;
+            bool receiver_found = false;
+            
+            // check sender validity
+            for(auto& object : objects)
+            {
+                auto& type = object.second;
+                
+                if(!sender_found && type.ref == sender_ref)
+                {
+                    sender_found = true;
+                    
+                    const auto outlet_count = type.member("outlets").second.array.size();
+                    if(sender_outlet >= outlet_count)
+                    {
+                        // bad outlet
+                        return true;
+                    }
+                }
+                
+                if(!receiver_found && type.ref == receiver_ref)
+                {
+                    receiver_found = true;
+                    
+                    const auto inlet_count = type.member("inlets").second.array.size();
+                    if(receiver_inlet >= inlet_count)
+                    {
+                        // bad inlet
+                        return true;
+                    }
+                }
+                
+                if(sender_found && receiver_found)
+                {
+                    break;
+                }
+            }
+            
+            return (!sender_found || !receiver_found);
+        };
+        
+        auto& links = patcher.member("links").second.array;
+        
+        auto iter = links.begin();
+        const auto end_iter = links.cend();
+        for(; iter != end_iter;)
+        {
+            if (is_invalid_link(iter->second))
+            {
+                links.erase(iter++);
+            }
+            else
+            {
+                ++iter;
+            }
+        }
     }
     
     bool Converter::process(flip::BackEndIR & backend)
     {
-        bool success = false;
-        
-        process_rollback(backend);
-        
         std::string current_version(KIWI_MODEL_VERSION_STRING);
         
         if (current_version.compare(backend.version) >= 0)
         {
-            if (backend.version.compare("v1") == 0)
+            if (backend.version == "v1")
             {
                 convert_v1_v2(backend);
             }
             
-            if (backend.version.compare("v2") == 0 || backend.version.compare("v3") == 0)
+            // no change from v2 to v3 !
+            
+            if (backend.version == "v2")
             {
-                success = true;
+                backend.complete_conversion("v3");
+            }
+            
+            if (backend.version == "v3")
+            {
+                convert_v3_v4(backend);
+                remove_invalid_links(backend);
             }
         }
         
-        return success;
-    }
-    
-    void Converter::process_rollback(flip::BackEndIR & backend)
-    {
+        return (backend.version == current_version);
     }
 }}

--- a/Modules/KiwiModel/KiwiModel_Converters/KiwiModel_Converter.h
+++ b/Modules/KiwiModel/KiwiModel_Converters/KiwiModel_Converter.h
@@ -42,9 +42,13 @@ namespace kiwi { namespace model {
     private: // methods
         
         //! @brief Converts a v1 data model to a v2 data model.
-        static void convert_v1_v2(flip::BackEndIR & backend);
+        static void convert_v1_v2(flip::BackEndIR& backend);
         
-        //! @brief Rollbacks depecrated revisions.
-        static void process_rollback(flip::BackEndIR & backend);
+        //! @brief Converts a v3 data model to a v4 data model.
+        static void convert_v3_v4(flip::BackEndIR& backend);
+        
+        //! @brief Removes invalid links
+        static void remove_invalid_links(flip::BackEndIR& backend);
     };
+    
 }}

--- a/Modules/KiwiModel/KiwiModel_Def.h
+++ b/Modules/KiwiModel/KiwiModel_Def.h
@@ -21,4 +21,4 @@
 
 #pragma once
 
-#define KIWI_MODEL_VERSION_STRING "v3"
+#define KIWI_MODEL_VERSION_STRING "v4"

--- a/Modules/KiwiModel/KiwiModel_Error.h
+++ b/Modules/KiwiModel/KiwiModel_Error.h
@@ -33,12 +33,14 @@ namespace kiwi { namespace model {
     public:
         
         //! @brief The std::string constructor.
-        explicit Error(const std::string& message) :
-        std::runtime_error(std::string("kiwi::model ") + message) {}
+        explicit Error(std::string const& message)
+        : std::runtime_error(message)
+        {}
         
         //! @brief The const char* constructor.
-        explicit Error(const char* message) :
-        std::runtime_error(std::string("kiwi::model ") + std::string(message)) {}
+        explicit Error(const char* message)
+        : std::runtime_error(std::string(message))
+        {}
         
         //! @brief The destructor.
         virtual inline ~Error() noexcept = default;

--- a/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Bang.cpp
+++ b/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Bang.cpp
@@ -56,6 +56,7 @@ namespace kiwi { namespace model {
         }
         
         addSignal<>(Signal::TriggerBang, *this);
+        addSignal<>(Signal::FlashBang, *this);
         setRatio(1.);
         setMinWidth(20.);
         setWidth(20);
@@ -67,6 +68,7 @@ namespace kiwi { namespace model {
     Object(d)
     {
         addSignal<>(Signal::TriggerBang, *this);
+        addSignal<>(Signal::FlashBang, *this);
     }
     
     std::string Bang::getIODescription(bool is_inlet, size_t index) const

--- a/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Bang.h
+++ b/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Bang.h
@@ -35,7 +35,8 @@ namespace kiwi { namespace model {
         
         enum Signal : SignalKey
         {
-            TriggerBang
+            TriggerBang,
+            FlashBang
         };
         
     public: // methods

--- a/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Hub.cpp
+++ b/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Hub.cpp
@@ -31,20 +31,20 @@ namespace kiwi { namespace model {
     void Hub::declare()
     {
         // Objectclass
-        std::unique_ptr<ObjectClass> hub_class(new ObjectClass("hub", &Hub::create));
+        auto kiwi_class = std::make_unique<ObjectClass>("hub", &Hub::create);
         
         // Parameters
-        std::unique_ptr<ParameterClass> param_message(new ParameterClass(tool::Parameter::Type::String));
+        auto param_message = std::make_unique<ParameterClass>(tool::Parameter::Type::String);
         
-        hub_class->addAttribute("message", std::move(param_message));
+        kiwi_class->addAttribute("message", std::move(param_message));
         
         // DataModel
-        flip::Class<Hub> & hub_model = DataModel::declare<Hub>()
-                                                  .name(hub_class->getModelName().c_str())
-                                                  .inherit<Object>()
-                                                  .member<flip::Message<std::string>, &Hub::m_message>("message");
+        auto& flip_class = DataModel::declare<Hub>()
+        .name(kiwi_class->getModelName().c_str())
+        .inherit<Object>()
+        .member<flip::Message<std::string>, &Hub::m_message>("message");
         
-        Factory::add<Hub>(std::move(hub_class), hub_model);
+        Factory::add<Hub>(std::move(kiwi_class), flip_class);
     }
     
     std::unique_ptr<Object> Hub::create(std::vector<tool::Atom> const& args)
@@ -52,21 +52,24 @@ namespace kiwi { namespace model {
         return std::make_unique<Hub>(args);
     }
     
-    Hub::Hub(std::vector<tool::Atom> const& args):
-    Object(),
-    m_message()
+    Hub::Hub(std::vector<tool::Atom> const& args)
+    : Object()
+    , m_message()
     {
         if (args.size() > 0)
             throw Error("message too many arguments");
         
         pushInlet({PinType::IType::Control});
         pushOutlet(PinType::IType::Control);
+        
+        m_message.disable_in_undo();
     }
     
-    Hub::Hub(flip::Default& d):
-    Object(d),
-    m_message()
+    Hub::Hub(flip::Default& d)
+    : Object(d)
+    , m_message()
     {
+        m_message.disable_in_undo();
     }
     
     void Hub::writeAttribute(std::string const& name, tool::Parameter const& parameter)

--- a/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Pack.cpp
+++ b/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Pack.cpp
@@ -73,8 +73,15 @@ namespace kiwi { namespace model {
                     default: return "null";
                 }
             }();
+            
+            auto description = type_str + " atom " + std::to_string(index + 1) + " in list";
+            
+            if(index == 0)
+            {
+                description += ", causes output";
+            }
 
-            return type_str + " atom " + std::to_string(index + 1) + " in list";
+            return std::move(description);
         }
         
         return {};

--- a/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Random.cpp
+++ b/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Random.cpp
@@ -30,11 +30,13 @@ namespace kiwi { namespace model {
     
     void Random::declare()
     {
-        std::unique_ptr<ObjectClass> random_class(new ObjectClass("random", &Random::create));
+        auto kiwi_class = std::make_unique<ObjectClass>("random", &Random::create);
         
-        flip::Class<Random> & random_model = DataModel::declare<Random>().name(random_class->getModelName().c_str()).inherit<Object>();
+        auto& flip_class = DataModel::declare<Random>()
+        .name(kiwi_class->getModelName().c_str())
+        .inherit<Object>();
         
-        Factory::add<Random>(std::move(random_class), random_model);
+        Factory::add<Random>(std::move(kiwi_class), flip_class);
     }
     
     std::unique_ptr<Object> Random::create(std::vector<tool::Atom> const& args)
@@ -46,22 +48,25 @@ namespace kiwi { namespace model {
     {
         if (args.size() > 2)
         {
-            throw Error("random too many arguments");
-        }
-        
-        if (args.size() > 1 && !args[1].isNumber())
-        {
-            throw Error("random seed argument must be a number");
+            throw Error("random: too many arguments");
         }
         
         if (args.size() > 0 && !args[0].isNumber())
         {
-            throw Error("random range argument must be a number");
+            throw Error("random: range argument must be a number");
         }
         
-        pushInlet({PinType::IType::Control});
-        pushInlet({PinType::IType::Control});
-        pushInlet({PinType::IType::Control});
+        if (args.size() > 1 && !args[1].isNumber())
+        {
+            throw Error("random: seed argument must be a number");
+        }
+        
+        pushInlet({PinType::IType::Control}); // bang or seed message inlet
+        
+        if (args.size() == 0)
+        {
+            pushInlet({PinType::IType::Control}); // range inlet
+        }
         
         pushOutlet(PinType::IType::Control);
     }
@@ -72,23 +77,19 @@ namespace kiwi { namespace model {
         {
             if (index == 0)
             {
-                return "bang causes random number generation";
+                return "bang causes random number generation, seed sets the seed";
             }
             else if (index == 1)
             {
-                return "Sets the range";
-            }
-            else if (index == 2)
-            {
-                return "Sets the seed";
+                return "Sets the maximum range (exclusive)";
             }
         }
-        else
+        else if(index == 0)
         {
-            return "Ouputs ramdom number";
+            return "Outputs random number";
         }
      
-        return "";
+        return {};
     }
     
 }}

--- a/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Select.cpp
+++ b/Modules/KiwiModel/KiwiModel_Objects/KiwiModel_Select.cpp
@@ -30,13 +30,15 @@ namespace kiwi { namespace model {
     
     void Select::declare()
     {
-        std::unique_ptr<ObjectClass> select_class(new ObjectClass("select", &Select::create));
+        auto kiwi_class = std::make_unique<ObjectClass>("select", &Select::create);
         
-        flip::Class<Select> & select_model = DataModel::declare<Select>()
-                                            .name(select_class->getModelName().c_str())
-                                            .inherit<Object>();
+        kiwi_class->addAlias("sel");
         
-        Factory::add<Select>(std::move(select_class), select_model);
+        auto& flip_class = (DataModel::declare<Select>()
+                            .name(kiwi_class->getModelName().c_str())
+                            .inherit<Object>());
+        
+        Factory::add<Select>(std::move(kiwi_class), flip_class);
     }
     
     std::unique_ptr<Object> Select::create(std::vector<tool::Atom> const& args)
@@ -79,13 +81,15 @@ namespace kiwi { namespace model {
         }
         else
         {
-            if (index == getArguments().size())
+            auto const& args = getArguments();
+            
+            if (index == args.size())
             {
-                description = "Ouptuts bang if input doesn't match";
+                description = "Input if doesn't match";
             }
             else
             {
-                description = "Outputs bang if input matches " + getArguments()[index].getString();
+                description = "Outputs bang if input matches \"" + tool::AtomHelper::toString(args[index]) + "\"";
             }
         }
         

--- a/Ressources/Project/Xcode/Info.plist
+++ b/Ressources/Project/Xcode/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/Scripts/setup-Win32.iss
+++ b/Scripts/setup-Win32.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Kiwi"
-#define MyAppVersion "v1.0.0-beta"
+#define MyAppVersion "v1.0.1"
 #define MyAppPublisher "CICM"
 #define MyAppURL "http://kiwi.mshparisnord.fr/"
 #define MyAppExeName "Kiwi.exe"
@@ -61,4 +61,3 @@ Root: HKCR; Subkey: "{#MyAppName}\shell\open\command";  ValueData: """{app}\{#My
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-

--- a/Scripts/setup-x64.iss
+++ b/Scripts/setup-x64.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Kiwi"
-#define MyAppVersion "v1.0.0-beta"
+#define MyAppVersion "v1.0.1"
 #define MyAppPublisher "CICM"
 #define MyAppURL "http://kiwi.mshparisnord.fr/"
 #define MyAppExeName "Kiwi.exe"
@@ -61,4 +61,3 @@ Root: HKCR; Subkey: "{#MyAppName}\shell\open\command";  ValueData: """{app}\{#My
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-


### PR DESCRIPTION
Changelog : 

[select] :
- fix bad output when symbol match
- output input if doesn't match and not bang
- fix io description
- Add [sel] alias

[number] :
- Add patcherview shortcuts (f/i)
- Output only when value has changed
- hide mouse on drag
- improve decimal drag

[number~] :
-  updated draw method

[bang] :
- Add set method (flash without output)

[random] : (breaking-changes)
- default range is 0 (was 100)
- output random value between 0 and range-1 (was 0 and range)
- fix warning and io typos
- default seed is 0 (was 1)
- a seed of 0 means that it is initialized with an unpredictable time value.
- seed can now be set
- Add a *seed* method and remove the seed inlet
- remove range inlet when the range argument is specified

misc:
- Allow undo/redo of [message] and [comment] text edition.
- Remove "kiwi::model" text prefix in model::Error